### PR TITLE
feat: show every calendar of an account, coloured per calendar

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -503,3 +503,50 @@ verified, not theorised); switching the attachment viewer to `asset:` or `blob:`
 URLs so `data:` could be dropped (a real option, but a behaviour change to a
 working feature for a marginal CSP win; revisit only if attachment sizes make the
 base64 round-trip a performance problem).
+
+## 2026-08-04 — The calendar shows every calendar of an account, coloured per calendar
+
+**Decision:** Calendar sync enumerates every calendar an account can see (Google
+`calendarList.list`, Graph `/me/calendars`) — its own, calendars shared with it,
+subscribed ones — instead of only the primary calendar, and tints each event
+with that calendar's own provider colour. Every calendar syncs; a per-calendar
+`is_visible` toggle (calendar-view legend + Settings → Calendar) filters at
+render time, so showing one again is instant rather than a poll away. Calendars
+without a provider colour (Graph's named presets have no documented hex) get a
+deterministic slot from an app palette, keyed on the calendar id so the colour
+never shuffles between launches. Creating events remains primary-calendar-only.
+**Context:** Only the primary calendar was ever fetched, so a shared team or
+family calendar was invisible in the app while being visible in Google's own UI.
+Two constraints shaped the answer: Google's `calendar.events` scope cannot list
+calendars, so `calendar.calendarlist.readonly` was added (the narrowest scope
+that grants it — every existing Gmail account must re-consent, and the Google
+verification submission has to list it); and providers reuse a single event id
+across every calendar an event appears in, so `calendar_events` was re-keyed to
+`(account_id, calendar_id, provider_event_id)` in V022 — under the old key one
+copy silently overwrote the other.
+**Rejected:** Syncing only the calendars the provider marks as shown
+(`selected`) with no in-app override — the provider flag is a fine *default* for
+a newly seen calendar but a poor permanent policy. Not syncing hidden calendars
+— saves API calls but makes every un-hide wait for the next 5-minute poll.
+Assigning app-palette colours to everything — would not match the colours the
+user already recognises from Google Calendar. Broadening to `calendar.readonly`
+— grants reading every calendar's full contents when only the list is needed.
+Mapping Graph's named colour presets to invented hexes — the guesses would not
+match Outlook anyway, so those calendars use the app palette instead.
+
+## 2026-08-04 — Hidden calendars are hidden from what acts, not just from the grid
+
+**Decision:** Two event listings exist. `list_calendar_events` returns every
+event and backs the calendar view, which filters client-side so the visibility
+toggle is instant. `list_visible_calendar_events` excludes hidden calendars and
+backs everything that *acts* on events: meeting notifications, the chat
+`list_calendar_events` tool (and the weekly-report preseed through it), and the
+CLI `/calendar` command. Events whose calendar has no registry row yet count as
+visible.
+**Context:** Multi-calendar sync means a hidden holiday or team calendar would
+otherwise raise desktop meeting reminders and turn up in chat answers, which
+reads as a bug — the user switched that calendar off.
+**Rejected:** One filtered listing everywhere — the calendar view needs the
+unfiltered set to re-filter locally on toggle without a refetch. Leaving
+notifications and chat unfiltered — simpler, but surfaces exactly what the user
+asked to hide.

--- a/src-tauri/migrations/V022__calendars.sql
+++ b/src-tauri/migrations/V022__calendars.sql
@@ -1,0 +1,106 @@
+-- V022: multi-calendar support.
+--
+-- Until now sync hard-coded the account's primary calendar (Google
+-- `calendars/primary`, Graph `/me/calendarView`). Accounts can own several
+-- calendars and subscribe to calendars shared with them, each carrying its own
+-- colour in the provider's UI. This migration adds the calendar registry and
+-- re-keys events so the same event id can live in more than one calendar.
+
+-- One row per calendar the account can see (owned, shared-with-me, subscribed).
+-- Refreshed on every sync from Google `calendarList.list` / Graph
+-- `/me/calendars`; `is_visible` is the user's local show/hide toggle and is
+-- deliberately NOT overwritten by sync.
+CREATE TABLE IF NOT EXISTS calendars (
+    id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    -- Provider calendar id: an email-like address on Google
+    -- ("…@group.calendar.google.com", or the literal "primary" alias) and an
+    -- opaque base64-ish id on Graph.
+    provider_calendar_id TEXT NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    -- Provider colour as "#rrggbb"; empty when the provider reported none, in
+    -- which case the UI falls back to a deterministic palette slot.
+    color TEXT NOT NULL DEFAULT '',
+    is_primary INTEGER NOT NULL DEFAULT 0,
+    -- Google calendarList accessRole, with Graph mapped onto the same set
+    -- (canEdit → writer, otherwise reader). Drives whether writes are offered.
+    access_role TEXT NOT NULL DEFAULT 'reader'
+        CHECK (access_role IN ('owner', 'writer', 'reader', 'freeBusyReader')),
+    -- Local show/hide toggle (Settings → Calendar). Sync preserves it.
+    is_visible INTEGER NOT NULL DEFAULT 1,
+    -- Provider list order, so the UI lists calendars the way the provider does
+    -- (primary first).
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE,
+    UNIQUE (account_id, provider_calendar_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_calendars_account
+    ON calendars(account_id, sort_order);
+
+-- Re-key calendar_events from (account_id, provider_event_id) to
+-- (account_id, calendar_id, provider_event_id).
+--
+-- Why the table rebuild: Google hands out the SAME event id for every copy of
+-- a meeting you are an attendee on, so one event visible in both your primary
+-- calendar and a calendar shared with you collides under the old unique key —
+-- the second copy silently overwrote the first. SQLite cannot drop a UNIQUE
+-- constraint in place, hence the copy/drop/rename.
+--
+-- Row ids gain the calendar segment for the same reason. Ids are opaque
+-- (never parsed apart), so rewriting them is safe; existing rows are all
+-- 'primary' because that is all the old sync ever wrote.
+CREATE TABLE calendar_events_v022 (
+    id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    provider_event_id TEXT NOT NULL,
+    calendar_id TEXT NOT NULL DEFAULT 'primary',
+    title TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    location TEXT NOT NULL DEFAULT '',
+    start_time INTEGER NOT NULL,
+    end_time INTEGER NOT NULL,
+    is_all_day INTEGER NOT NULL DEFAULT 0,
+    timezone TEXT NOT NULL DEFAULT '',
+    organizer TEXT NOT NULL DEFAULT '',
+    attendees_json TEXT NOT NULL DEFAULT '[]',
+    meeting_link TEXT,
+    meeting_platform TEXT,
+    status TEXT NOT NULL DEFAULT 'confirmed'
+        CHECK (status IN ('confirmed', 'tentative', 'cancelled')),
+    html_link TEXT,
+    notified_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    recurring_event_id TEXT,
+    FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE,
+    UNIQUE (account_id, calendar_id, provider_event_id)
+);
+
+INSERT INTO calendar_events_v022 (
+    id, account_id, provider_event_id, calendar_id, title, description, location,
+    start_time, end_time, is_all_day, timezone, organizer, attendees_json,
+    meeting_link, meeting_platform, status, html_link, notified_at,
+    created_at, updated_at, recurring_event_id
+)
+SELECT
+    account_id || ':' || calendar_id || ':' || provider_event_id,
+    account_id, provider_event_id, calendar_id, title, description, location,
+    start_time, end_time, is_all_day, timezone, organizer, attendees_json,
+    meeting_link, meeting_platform, status, html_link, notified_at,
+    created_at, updated_at, recurring_event_id
+FROM calendar_events;
+
+DROP TABLE calendar_events;
+
+ALTER TABLE calendar_events_v022 RENAME TO calendar_events;
+
+-- Recreate the indexes the rebuild dropped (V011 range index, V012 series index).
+CREATE INDEX IF NOT EXISTS idx_calendar_events_account_start
+    ON calendar_events(account_id, start_time);
+
+CREATE INDEX IF NOT EXISTS idx_calendar_events_account_master
+    ON calendar_events(account_id, recurring_event_id)
+    WHERE recurring_event_id IS NOT NULL;

--- a/src-tauri/src/cli/commands.rs
+++ b/src-tauri/src/cli/commands.rs
@@ -353,7 +353,9 @@ pub async fn dispatch(session: &mut CliSession, command: Command) -> Result<()> 
                 .map(|dt| dt.timestamp())
                 .unwrap_or(now);
             let range_end = start_of_today + days.max(1).saturating_mul(86_400);
-            let events = session.db.list_calendar_events(&account, start_of_today, range_end)?;
+            let events = session
+                .db
+                .list_visible_calendar_events(&account, start_of_today, range_end)?;
             if next {
                 // Events are start-time ordered; the first not-yet-started one
                 // is the next meeting.

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1,6 +1,26 @@
-use crate::models::CalendarEvent;
+use crate::models::{Calendar, CalendarEvent};
 use crate::{AppError, AppState};
 use tauri::State;
+
+/// Every calendar the account can see (its own, shared-with-it, subscribed),
+/// in the provider's list order with the primary first. The frontend uses this
+/// for per-calendar colours and the show/hide filter.
+#[tauri::command]
+pub async fn get_calendars(state: State<'_, AppState>, account_id: String) -> Result<Vec<Calendar>, AppError> {
+    state.db.list_calendars(&account_id)
+}
+
+/// Show or hide one calendar in the calendar view. Hidden calendars keep
+/// syncing, so toggling one back on is instant.
+#[tauri::command]
+pub async fn set_calendar_visible(
+    state: State<'_, AppState>,
+    account_id: String,
+    calendar_id: String,
+    visible: bool,
+) -> Result<(), AppError> {
+    state.db.set_calendar_visible(&account_id, &calendar_id, visible)
+}
 
 /// Events overlapping `[range_start, range_end)` for one account. The calendar
 /// surface is per-account only (docs/DECISIONS.md) — there is deliberately no
@@ -64,9 +84,13 @@ pub async fn create_calendar_event(
 /// sends a cancellation; `message` is included where supported (Outlook —
 /// Google's API only sends its standard cancellation email).
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command boundary — mirrors the dialog's fields 1:1
 pub async fn delete_calendar_event(
     state: State<'_, AppState>,
     account_id: String,
+    // Option so pre-multi-calendar callers keep working; the event carries its
+    // own calendar id, and everything synced before V022 lived in "primary".
+    calendar_id: Option<String>,
     provider_event_id: String,
     notify_attendees: bool,
     // Option so a frontend `null` / omitted field can never fail arg
@@ -87,6 +111,7 @@ pub async fn delete_calendar_event(
         &state.db,
         &account.id,
         provider.as_ref(),
+        calendar_id.as_deref().unwrap_or("primary"),
         &provider_event_id,
         scope,
         notify_attendees,

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -1,6 +1,8 @@
 //! Calendar event storage. Rows are provider-expanded recurrence instances
-//! keyed by `(account_id, provider_event_id)`; all reads are account-scoped
-//! (the calendar surface is per-account by decision — docs/DECISIONS.md).
+//! keyed by `(account_id, calendar_id, provider_event_id)`; all reads are
+//! account-scoped (the calendar surface is per-account by decision —
+//! docs/DECISIONS.md). One account can hold several calendars: its own, plus
+//! any shared with it — see `db::calendars` for the registry.
 
 use crate::db::Database;
 use crate::models::error::Result;
@@ -75,9 +77,11 @@ impl Database {
     }
 
     /// Insert or update a batch of events in one transaction. Conflict target
-    /// is `(account_id, provider_event_id)` — a re-synced instance updates in
-    /// place and keeps its row id and `notified_at` marker (so an event whose
-    /// details change after the reminder fired is not re-notified).
+    /// is `(account_id, calendar_id, provider_event_id)` — a re-synced instance
+    /// updates in place and keeps its row id and `notified_at` marker (so an
+    /// event whose details change after the reminder fired is not re-notified).
+    /// The calendar is part of the key because providers reuse one event id
+    /// across every calendar the event is visible in.
     pub fn upsert_calendar_events(&self, events: &[CalendarEvent]) -> Result<()> {
         let mut conn = self.connection();
         let tx = conn.transaction()?;
@@ -89,8 +93,7 @@ impl Database {
                      meeting_link, meeting_platform, status, html_link, notified_at, created_at, updated_at,
                      recurring_event_id
                  ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)
-                 ON CONFLICT (account_id, provider_event_id) DO UPDATE SET
-                     calendar_id = excluded.calendar_id,
+                 ON CONFLICT (account_id, calendar_id, provider_event_id) DO UPDATE SET
                      title = excluded.title,
                      description = excluded.description,
                      location = excluded.location,
@@ -163,28 +166,69 @@ impl Database {
         Ok(result)
     }
 
-    /// Delete one event by its provider id (incremental sync saw a cancellation).
-    pub fn delete_calendar_event(&self, account_id: &str, provider_event_id: &str) -> Result<()> {
+    /// Like [`Self::list_calendar_events`], but excluding calendars the user
+    /// hid in Settings → Calendar.
+    ///
+    /// This is the listing for anything that *acts* on events — meeting
+    /// reminders, the chat calendar tool — because a hidden calendar must not
+    /// pop up a notification or turn up in a chat answer. The calendar view
+    /// deliberately uses the unfiltered listing instead and filters client-side,
+    /// so toggling a calendar back on is instant rather than a refetch.
+    ///
+    /// Events whose calendar has no registry row yet (synced before the
+    /// registry existed) count as visible — never silently drop them.
+    pub fn list_visible_calendar_events(
+        &self,
+        account_id: &str,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<Vec<CalendarEvent>> {
+        let conn = self.reader();
+        let sql = format!(
+            "SELECT {EVENT_COLUMNS} FROM calendar_events
+             WHERE account_id = ?1 AND start_time < ?3 AND end_time > ?2 AND status != 'cancelled'
+               AND calendar_id NOT IN (
+                   SELECT provider_calendar_id FROM calendars
+                   WHERE account_id = ?1 AND is_visible = 0
+               )
+             ORDER BY start_time ASC, end_time ASC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params![account_id, range_start, range_end], row_to_event)?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row?);
+        }
+        Ok(result)
+    }
+
+    /// Delete one event from one calendar (the user deleted it, or an
+    /// incremental sync saw a cancellation).
+    pub fn delete_calendar_event(&self, account_id: &str, calendar_id: &str, provider_event_id: &str) -> Result<()> {
         let conn = self.connection();
         conn.execute(
-            "DELETE FROM calendar_events WHERE account_id = ?1 AND provider_event_id = ?2",
-            params![account_id, provider_event_id],
+            "DELETE FROM calendar_events WHERE account_id = ?1 AND calendar_id = ?2 AND provider_event_id = ?3",
+            params![account_id, calendar_id, provider_event_id],
         )?;
         Ok(())
     }
 
-    /// One event by its provider id — the delete command resolves the clicked
-    /// instance into its series linkage this way.
+    /// One event by its calendar + provider id — the delete command resolves
+    /// the clicked instance into its series linkage this way. The calendar is
+    /// part of the lookup because the same event id can exist in several.
     pub fn get_calendar_event_by_provider_id(
         &self,
         account_id: &str,
+        calendar_id: &str,
         provider_event_id: &str,
     ) -> Result<Option<CalendarEvent>> {
         let conn = self.reader();
-        let sql =
-            format!("SELECT {EVENT_COLUMNS} FROM calendar_events WHERE account_id = ?1 AND provider_event_id = ?2");
+        let sql = format!(
+            "SELECT {EVENT_COLUMNS} FROM calendar_events
+             WHERE account_id = ?1 AND calendar_id = ?2 AND provider_event_id = ?3"
+        );
         let mut stmt = conn.prepare(&sql)?;
-        match stmt.query_row(params![account_id, provider_event_id], row_to_event) {
+        match stmt.query_row(params![account_id, calendar_id, provider_event_id], row_to_event) {
             Ok(event) => Ok(Some(event)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(e.into()),
@@ -194,12 +238,18 @@ impl Database {
     /// Delete every stored instance of a recurring series (whole-series delete).
     /// Matches instances linked via `recurring_event_id` AND a possible master
     /// row stored under the master id itself.
-    pub fn delete_calendar_events_for_master(&self, account_id: &str, master_id: &str) -> Result<()> {
+    pub fn delete_calendar_events_for_master(
+        &self,
+        account_id: &str,
+        calendar_id: &str,
+        master_id: &str,
+    ) -> Result<()> {
         let conn = self.connection();
         conn.execute(
             "DELETE FROM calendar_events
-             WHERE account_id = ?1 AND (recurring_event_id = ?2 OR provider_event_id = ?2)",
-            params![account_id, master_id],
+             WHERE account_id = ?1 AND calendar_id = ?2
+               AND (recurring_event_id = ?3 OR provider_event_id = ?3)",
+            params![account_id, calendar_id, master_id],
         )?;
         Ok(())
     }
@@ -209,14 +259,15 @@ impl Database {
     pub fn delete_calendar_events_for_master_from(
         &self,
         account_id: &str,
+        calendar_id: &str,
         master_id: &str,
         from_start: i64,
     ) -> Result<()> {
         let conn = self.connection();
         conn.execute(
             "DELETE FROM calendar_events
-             WHERE account_id = ?1 AND recurring_event_id = ?2 AND start_time >= ?3",
-            params![account_id, master_id, from_start],
+             WHERE account_id = ?1 AND calendar_id = ?2 AND recurring_event_id = ?3 AND start_time >= ?4",
+            params![account_id, calendar_id, master_id, from_start],
         )?;
         Ok(())
     }
@@ -226,19 +277,59 @@ impl Database {
     /// every fetched instance with `updated_at = run_started_at`, so anything
     /// older inside the window was removed upstream. Upsert-then-sweep (rather
     /// than delete-then-insert) keeps `notified_at` on surviving rows.
+    ///
+    /// Scoped to `calendar_ids` — the calendars whose fetch actually succeeded
+    /// this run. A calendar that errored is left completely untouched instead
+    /// of having its events blanked by a sweep that never saw them.
     pub fn delete_stale_calendar_events(
         &self,
         account_id: &str,
+        calendar_ids: &[String],
         window_start: i64,
         window_end: i64,
         run_started_at: i64,
     ) -> Result<()> {
+        if calendar_ids.is_empty() {
+            return Ok(());
+        }
         let conn = self.connection();
-        conn.execute(
+        let placeholders = (0..calendar_ids.len())
+            .map(|i| format!("?{}", i + 5))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "DELETE FROM calendar_events
-             WHERE account_id = ?1 AND start_time >= ?2 AND start_time < ?3 AND updated_at < ?4",
-            params![account_id, window_start, window_end, run_started_at],
-        )?;
+             WHERE account_id = ?1 AND start_time >= ?2 AND start_time < ?3 AND updated_at < ?4
+               AND calendar_id IN ({placeholders})"
+        );
+        let mut args: Vec<&dyn rusqlite::ToSql> = vec![&account_id, &window_start, &window_end, &run_started_at];
+        for id in calendar_ids {
+            args.push(id);
+        }
+        conn.execute(&sql, args.as_slice())?;
+        Ok(())
+    }
+
+    /// Drop every event belonging to a calendar the account no longer has
+    /// (unsubscribed, or sharing revoked). Called only after a successful
+    /// calendar-list fetch — otherwise a transient list failure would delete
+    /// the whole mirror.
+    pub fn delete_calendar_events_not_in(&self, account_id: &str, live_calendar_ids: &[String]) -> Result<()> {
+        let conn = self.connection();
+        if live_calendar_ids.is_empty() {
+            conn.execute("DELETE FROM calendar_events WHERE account_id = ?1", params![account_id])?;
+            return Ok(());
+        }
+        let placeholders = (0..live_calendar_ids.len())
+            .map(|i| format!("?{}", i + 2))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("DELETE FROM calendar_events WHERE account_id = ?1 AND calendar_id NOT IN ({placeholders})");
+        let mut args: Vec<&dyn rusqlite::ToSql> = vec![&account_id];
+        for id in live_calendar_ids {
+            args.push(id);
+        }
+        conn.execute(&sql, args.as_slice())?;
         Ok(())
     }
 
@@ -285,11 +376,15 @@ mod tests {
     use super::*;
 
     fn event(account_id: &str, provider_event_id: &str, start: i64, end: i64) -> CalendarEvent {
+        event_in(account_id, "primary", provider_event_id, start, end)
+    }
+
+    fn event_in(account_id: &str, calendar_id: &str, provider_event_id: &str, start: i64, end: i64) -> CalendarEvent {
         CalendarEvent {
-            id: format!("{account_id}:{provider_event_id}"),
+            id: format!("{account_id}:{calendar_id}:{provider_event_id}"),
             account_id: account_id.to_string(),
             provider_event_id: provider_event_id.to_string(),
-            calendar_id: "primary".to_string(),
+            calendar_id: calendar_id.to_string(),
             title: "Standup".to_string(),
             description: String::new(),
             location: String::new(),
@@ -356,6 +451,140 @@ mod tests {
     }
 
     #[test]
+    fn visible_listing_skips_events_from_hidden_calendars() {
+        // Meeting reminders and the chat calendar tool must not surface a
+        // calendar the user switched off in Settings → Calendar.
+        let db = test_db();
+        db.upsert_calendars(&[
+            crate::models::Calendar {
+                id: "acc1:primary".to_string(),
+                account_id: "acc1".to_string(),
+                provider_calendar_id: "primary".to_string(),
+                name: "Personal".to_string(),
+                color: "#039be5".to_string(),
+                is_primary: true,
+                access_role: "owner".to_string(),
+                is_visible: true,
+                sort_order: 0,
+                created_at: 0,
+                updated_at: 0,
+            },
+            crate::models::Calendar {
+                id: "acc1:holidays".to_string(),
+                account_id: "acc1".to_string(),
+                provider_calendar_id: "holidays".to_string(),
+                name: "Holidays".to_string(),
+                color: "#0b8043".to_string(),
+                is_primary: false,
+                access_role: "reader".to_string(),
+                is_visible: false,
+                sort_order: 1,
+                created_at: 0,
+                updated_at: 0,
+            },
+        ])
+        .expect("seed calendars");
+        db.upsert_calendar_events(&[
+            event_in("acc1", "primary", "mine", 100, 200),
+            event_in("acc1", "holidays", "bank-holiday", 100, 200),
+        ])
+        .expect("upsert");
+
+        let all = db.list_calendar_events("acc1", 0, 1_000).expect("list all");
+        let visible = db.list_visible_calendar_events("acc1", 0, 1_000).expect("list visible");
+
+        assert_eq!(
+            all.len(),
+            2,
+            "the calendar view still gets every event to filter itself"
+        );
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].provider_event_id, "mine");
+    }
+
+    #[test]
+    fn visible_listing_keeps_events_whose_calendar_is_not_registered_yet() {
+        // Events synced before the registry exists (or by an older build) must
+        // not silently vanish from reminders.
+        let db = test_db();
+        db.upsert_calendar_events(&[event_in("acc1", "primary", "ev1", 100, 200)])
+            .expect("upsert");
+
+        let visible = db.list_visible_calendar_events("acc1", 0, 1_000).expect("list");
+
+        assert_eq!(visible.len(), 1);
+    }
+
+    #[test]
+    fn the_same_event_id_in_two_calendars_is_stored_twice() {
+        // Google reuses one event id across every copy of a meeting you are an
+        // attendee on, so a meeting visible in both your own calendar and a
+        // calendar shared with you arrives twice with the same id. Keying on
+        // (account, event) alone made the second copy overwrite the first.
+        let db = test_db();
+        let mine = event_in("acc1", "primary", "shared-ev", 100, 200);
+        let theirs = event_in("acc1", "team@group.calendar.google.com", "shared-ev", 100, 200);
+
+        db.upsert_calendar_events(&[mine, theirs]).expect("upsert");
+
+        let events = db.list_calendar_events("acc1", 0, 1_000).expect("list");
+        assert_eq!(events.len(), 2, "one row per (calendar, event), not one per event");
+        let mut calendars: Vec<&str> = events.iter().map(|e| e.calendar_id.as_str()).collect();
+        calendars.sort_unstable();
+        assert_eq!(calendars, vec!["primary", "team@group.calendar.google.com"]);
+    }
+
+    #[test]
+    fn stale_sweep_spares_calendars_that_were_not_synced_this_run() {
+        // A calendar whose fetch failed (access revoked mid-run, provider 5xx)
+        // is skipped, not swept — otherwise one flaky shared calendar would
+        // blank its events on every failed poll.
+        let db = test_db();
+        let fresh = event_in("acc1", "primary", "ev1", 100, 200);
+        let mut untouched = event_in("acc1", "team@group.calendar.google.com", "ev2", 100, 200);
+        untouched.updated_at = 1_000;
+        db.upsert_calendar_events(&[fresh, untouched]).expect("upsert");
+
+        // Only "primary" synced successfully in a run that started at 5_000.
+        db.delete_stale_calendar_events("acc1", &["primary".to_string()], 0, 1_000, 5_000)
+            .expect("sweep");
+
+        let events = db.list_calendar_events("acc1", 0, 1_000).expect("list");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].calendar_id, "team@group.calendar.google.com");
+    }
+
+    #[test]
+    fn stale_sweep_removes_events_of_the_synced_calendar() {
+        let db = test_db();
+        let mut stale = event_in("acc1", "primary", "ev1", 100, 200);
+        stale.updated_at = 1_000;
+        db.upsert_calendar_events(&[stale]).expect("upsert");
+
+        db.delete_stale_calendar_events("acc1", &["primary".to_string()], 0, 1_000, 5_000)
+            .expect("sweep");
+
+        assert!(db.list_calendar_events("acc1", 0, 1_000).expect("list").is_empty());
+    }
+
+    #[test]
+    fn events_of_a_calendar_the_user_no_longer_has_are_dropped() {
+        let db = test_db();
+        db.upsert_calendar_events(&[
+            event_in("acc1", "primary", "ev1", 100, 200),
+            event_in("acc1", "gone@group.calendar.google.com", "ev2", 100, 200),
+        ])
+        .expect("upsert");
+
+        db.delete_calendar_events_not_in("acc1", &["primary".to_string()])
+            .expect("sweep orphans");
+
+        let events = db.list_calendar_events("acc1", 0, 1_000).expect("list");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].calendar_id, "primary");
+    }
+
+    #[test]
     fn upsert_then_list_roundtrips_all_fields() {
         let db = test_db();
         let e = event("acc1", "ev1", 100, 200);
@@ -394,11 +623,11 @@ mod tests {
         assert_eq!(
             events.len(),
             1,
-            "conflict on (account, provider_event) must not duplicate"
+            "conflict on (account, calendar, provider_event) must not duplicate"
         );
         assert_eq!(events[0].title, "Standup (moved)");
         assert_eq!(events[0].start_time, 150);
-        assert_eq!(events[0].id, "acc1:ev1", "row id survives updates");
+        assert_eq!(events[0].id, "acc1:primary:ev1", "row id survives updates");
     }
 
     #[test]
@@ -406,7 +635,8 @@ mod tests {
         let db = test_db();
         db.upsert_calendar_events(&[event("acc1", "ev1", 100, 200)])
             .expect("insert");
-        db.mark_calendar_event_notified("acc1:ev1", 90).expect("mark notified");
+        db.mark_calendar_event_notified("acc1:primary:ev1", 90)
+            .expect("mark notified");
 
         db.upsert_calendar_events(&[event("acc1", "ev1", 110, 210)])
             .expect("re-sync");
@@ -465,7 +695,7 @@ mod tests {
         db.upsert_calendar_events(&[event("acc1", "ev1", 100, 200), event("acc1", "ev2", 300, 400)])
             .expect("upsert");
 
-        db.delete_calendar_event("acc1", "ev1").expect("delete");
+        db.delete_calendar_event("acc1", "primary", "ev1").expect("delete");
 
         let events = db.list_calendar_events("acc1", 0, 1_000).expect("list");
         assert_eq!(events.len(), 1);
@@ -487,7 +717,7 @@ mod tests {
         outside.updated_at = 1_000;
         db.upsert_calendar_events(&[stale, fresh, outside]).expect("upsert");
 
-        db.delete_stale_calendar_events("acc1", 0, 300, 5_000)
+        db.delete_stale_calendar_events("acc1", &["primary".to_string()], 0, 300, 5_000)
             .expect("delete stale");
 
         let events = db.list_calendar_events("acc1", 0, 1_000).expect("list");
@@ -528,17 +758,25 @@ mod tests {
         let db = test_db();
         db.upsert_calendar_events(&[event("acc1", "ev1", 100, 200)])
             .expect("upsert");
-        let found = db.get_calendar_event_by_provider_id("acc1", "ev1").expect("get");
+        let found = db
+            .get_calendar_event_by_provider_id("acc1", "primary", "ev1")
+            .expect("get");
         assert_eq!(found.expect("some").provider_event_id, "ev1");
         assert!(db
-            .get_calendar_event_by_provider_id("acc1", "missing")
+            .get_calendar_event_by_provider_id("acc1", "primary", "missing")
             .expect("get")
             .is_none());
         assert!(
-            db.get_calendar_event_by_provider_id("acc2", "ev1")
+            db.get_calendar_event_by_provider_id("acc2", "primary", "ev1")
                 .expect("get")
                 .is_none(),
             "account-scoped"
+        );
+        assert!(
+            db.get_calendar_event_by_provider_id("acc1", "other@group.calendar.google.com", "ev1")
+                .expect("get")
+                .is_none(),
+            "calendar-scoped: the same event id in another calendar is a different row"
         );
     }
 
@@ -554,7 +792,7 @@ mod tests {
         ])
         .expect("upsert");
 
-        db.delete_calendar_events_for_master("acc1", "m")
+        db.delete_calendar_events_for_master("acc1", "primary", "m")
             .expect("delete series");
 
         let acc1: Vec<String> = db
@@ -577,7 +815,7 @@ mod tests {
         ])
         .expect("upsert");
 
-        db.delete_calendar_events_for_master_from("acc1", "m", 200)
+        db.delete_calendar_events_for_master_from("acc1", "primary", "m", 200)
             .expect("truncate");
 
         let remaining: Vec<String> = db

--- a/src-tauri/src/db/calendars.rs
+++ b/src-tauri/src/db/calendars.rs
@@ -1,0 +1,442 @@
+//! Calendar registry: the set of calendars each account can see (its own,
+//! shared-with-me, subscribed). Rows are refreshed from the provider on every
+//! sync; the user's `is_visible` toggle is local state and is never clobbered
+//! by a refresh — see `migrations/V022__calendars.sql`.
+
+use crate::db::Database;
+use crate::models::error::Result;
+use crate::models::Calendar;
+use rusqlite::params;
+
+const CALENDAR_COLUMNS: &str = "id, account_id, provider_calendar_id, name, color, is_primary, \
+     access_role, is_visible, sort_order, created_at, updated_at";
+
+/// Stable row id for a calendar. Opaque — never parsed apart.
+pub fn calendar_row_id(account_id: &str, provider_calendar_id: &str) -> String {
+    format!("{account_id}:{provider_calendar_id}")
+}
+
+fn row_to_calendar(row: &rusqlite::Row) -> rusqlite::Result<Calendar> {
+    Ok(Calendar {
+        id: row.get(0)?,
+        account_id: row.get(1)?,
+        provider_calendar_id: row.get(2)?,
+        name: row.get(3)?,
+        color: row.get(4)?,
+        is_primary: row.get::<_, i32>(5)? != 0,
+        access_role: row.get(6)?,
+        is_visible: row.get::<_, i32>(7)? != 0,
+        sort_order: row.get(8)?,
+        created_at: row.get(9)?,
+        updated_at: row.get(10)?,
+    })
+}
+
+impl Database {
+    /// Insert or refresh a batch of calendars in one transaction. On conflict
+    /// the provider-owned fields update in place but `is_visible` is left
+    /// alone: hiding a calendar is a local decision and must survive every
+    /// subsequent sync.
+    pub fn upsert_calendars(&self, calendars: &[Calendar]) -> Result<()> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO calendars (
+                     id, account_id, provider_calendar_id, name, color, is_primary,
+                     access_role, is_visible, sort_order, created_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                 ON CONFLICT (account_id, provider_calendar_id) DO UPDATE SET
+                     name = excluded.name,
+                     color = excluded.color,
+                     is_primary = excluded.is_primary,
+                     access_role = excluded.access_role,
+                     sort_order = excluded.sort_order,
+                     updated_at = excluded.updated_at",
+            )?;
+            for calendar in calendars {
+                stmt.execute(params![
+                    calendar.id,
+                    calendar.account_id,
+                    calendar.provider_calendar_id,
+                    calendar.name,
+                    calendar.color,
+                    calendar.is_primary as i32,
+                    calendar.access_role,
+                    calendar.is_visible as i32,
+                    calendar.sort_order,
+                    calendar.created_at,
+                    calendar.updated_at,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Every calendar known for an account, in the provider's own list order
+    /// (primary first), then by name so the order is stable.
+    pub fn list_calendars(&self, account_id: &str) -> Result<Vec<Calendar>> {
+        let conn = self.reader();
+        let sql = format!(
+            "SELECT {CALENDAR_COLUMNS} FROM calendars
+             WHERE account_id = ?1
+             ORDER BY is_primary DESC, sort_order ASC, name ASC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params![account_id], row_to_calendar)?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row?);
+        }
+        Ok(result)
+    }
+
+    /// Show or hide one calendar (Settings → Calendar). Hiding filters it out
+    /// of the calendar view without stopping its sync, so re-showing it is
+    /// instant rather than waiting for the next poll.
+    pub fn set_calendar_visible(&self, account_id: &str, provider_calendar_id: &str, visible: bool) -> Result<()> {
+        let conn = self.connection();
+        conn.execute(
+            "UPDATE calendars SET is_visible = ?3 WHERE account_id = ?1 AND provider_calendar_id = ?2",
+            params![account_id, provider_calendar_id, visible as i32],
+        )?;
+        Ok(())
+    }
+
+    /// Drop calendars the provider no longer lists (unsubscribed, or access
+    /// revoked). Called only after a successful list fetch, so a failed sync
+    /// can never wipe the registry.
+    pub fn delete_calendars_not_in(&self, account_id: &str, live_provider_ids: &[String]) -> Result<()> {
+        let conn = self.connection();
+        if live_provider_ids.is_empty() {
+            conn.execute("DELETE FROM calendars WHERE account_id = ?1", params![account_id])?;
+            return Ok(());
+        }
+        let placeholders = (0..live_provider_ids.len())
+            .map(|i| format!("?{}", i + 2))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql =
+            format!("DELETE FROM calendars WHERE account_id = ?1 AND provider_calendar_id NOT IN ({placeholders})");
+        let mut args: Vec<&dyn rusqlite::ToSql> = vec![&account_id];
+        for id in live_provider_ids {
+            args.push(id);
+        }
+        conn.execute(&sql, args.as_slice())?;
+        Ok(())
+    }
+}
+
+/// Exercises the V022 `calendar_events` rebuild against a pre-V022 table.
+///
+/// The normal migration tests all start from an empty DB, so the
+/// `INSERT … SELECT` that carries existing rows across the rebuild is never
+/// executed with data in it — exactly the statement that would silently lose a
+/// user's synced calendar. This runs the real migration file against a
+/// hand-built old-shape table.
+#[cfg(test)]
+mod v022_rebuild_tests {
+    use rusqlite::Connection;
+
+    const V022: &str = include_str!("../../migrations/V022__calendars.sql");
+
+    /// `accounts` (for the FK) plus `calendar_events` in its V011+V012 shape.
+    fn pre_v022_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(
+            "CREATE TABLE accounts (id TEXT PRIMARY KEY);
+             INSERT INTO accounts (id) VALUES ('acc1');
+             CREATE TABLE calendar_events (
+                 id TEXT PRIMARY KEY,
+                 account_id TEXT NOT NULL,
+                 provider_event_id TEXT NOT NULL,
+                 calendar_id TEXT NOT NULL DEFAULT 'primary',
+                 title TEXT NOT NULL DEFAULT '',
+                 description TEXT NOT NULL DEFAULT '',
+                 location TEXT NOT NULL DEFAULT '',
+                 start_time INTEGER NOT NULL,
+                 end_time INTEGER NOT NULL,
+                 is_all_day INTEGER NOT NULL DEFAULT 0,
+                 timezone TEXT NOT NULL DEFAULT '',
+                 organizer TEXT NOT NULL DEFAULT '',
+                 attendees_json TEXT NOT NULL DEFAULT '[]',
+                 meeting_link TEXT,
+                 meeting_platform TEXT,
+                 status TEXT NOT NULL DEFAULT 'confirmed'
+                     CHECK (status IN ('confirmed', 'tentative', 'cancelled')),
+                 html_link TEXT,
+                 notified_at INTEGER,
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL,
+                 recurring_event_id TEXT,
+                 FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE,
+                 UNIQUE (account_id, provider_event_id)
+             );
+             CREATE INDEX idx_calendar_events_account_start
+                 ON calendar_events(account_id, start_time);
+             CREATE INDEX idx_calendar_events_account_master
+                 ON calendar_events(account_id, recurring_event_id)
+                 WHERE recurring_event_id IS NOT NULL;",
+        )
+        .expect("pre-V022 schema");
+        conn
+    }
+
+    fn seed_event(conn: &Connection, provider_event_id: &str, notified_at: Option<i64>) {
+        conn.execute(
+            "INSERT INTO calendar_events
+                 (id, account_id, provider_event_id, calendar_id, title, start_time, end_time,
+                  attendees_json, notified_at, created_at, updated_at)
+             VALUES (?1, 'acc1', ?2, 'primary', 'Standup', 100, 200, '[]', ?3, 10, 10)",
+            rusqlite::params![format!("acc1:{provider_event_id}"), provider_event_id, notified_at],
+        )
+        .expect("seed");
+    }
+
+    #[test]
+    fn existing_events_survive_the_rebuild_with_rewritten_ids() {
+        let conn = pre_v022_db();
+        seed_event(&conn, "ev1", Some(90));
+        seed_event(&conn, "ev2", None);
+
+        conn.execute_batch(V022).expect("apply V022");
+
+        let mut stmt = conn
+            .prepare("SELECT id, provider_event_id, calendar_id, notified_at FROM calendar_events ORDER BY id")
+            .expect("prepare");
+        let rows: Vec<(String, String, String, Option<i64>)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+            .expect("query")
+            .collect::<rusqlite::Result<_>>()
+            .expect("rows");
+
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "acc1:primary:ev1".to_string(),
+                    "ev1".to_string(),
+                    "primary".to_string(),
+                    Some(90)
+                ),
+                (
+                    "acc1:primary:ev2".to_string(),
+                    "ev2".to_string(),
+                    "primary".to_string(),
+                    None
+                ),
+            ],
+            "the rebuild must carry every row across, notified_at included"
+        );
+    }
+
+    #[test]
+    fn the_rebuilt_table_accepts_one_event_id_in_two_calendars() {
+        let conn = pre_v022_db();
+        seed_event(&conn, "shared-ev", None);
+        conn.execute_batch(V022).expect("apply V022");
+
+        conn.execute(
+            "INSERT INTO calendar_events
+                 (id, account_id, provider_event_id, calendar_id, title, start_time, end_time,
+                  attendees_json, created_at, updated_at)
+             VALUES ('acc1:team:shared-ev', 'acc1', 'shared-ev', 'team@group.calendar.google.com',
+                     'Standup', 100, 200, '[]', 10, 10)",
+            [],
+        )
+        .expect("the old UNIQUE(account, event) would have rejected this");
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM calendar_events", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn the_rebuild_recreates_the_indexes_it_dropped() {
+        let conn = pre_v022_db();
+        conn.execute_batch(V022).expect("apply V022");
+
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'calendar_events'")
+            .expect("prepare");
+        let names: Vec<String> = stmt
+            .query_map([], |r| r.get(0))
+            .expect("query")
+            .collect::<rusqlite::Result<_>>()
+            .expect("rows");
+
+        for required in [
+            "idx_calendar_events_account_start",
+            "idx_calendar_events_account_master",
+        ] {
+            assert!(
+                names.iter().any(|n| n == required),
+                "missing {required}, have {names:?}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn calendar(account_id: &str, provider_calendar_id: &str, name: &str, color: &str) -> Calendar {
+        Calendar {
+            id: calendar_row_id(account_id, provider_calendar_id),
+            account_id: account_id.to_string(),
+            provider_calendar_id: provider_calendar_id.to_string(),
+            name: name.to_string(),
+            color: color.to_string(),
+            is_primary: provider_calendar_id == "primary",
+            access_role: "owner".to_string(),
+            is_visible: true,
+            sort_order: 0,
+            created_at: 1_000,
+            updated_at: 1_000,
+        }
+    }
+
+    fn test_db() -> Database {
+        let db = Database::new_for_testing().expect("create test db");
+        db.seed_test_account("acc1");
+        db.seed_test_account("acc2");
+        db
+    }
+
+    #[test]
+    fn upsert_then_list_roundtrips_all_fields() {
+        let db = test_db();
+        let mut cal = calendar("acc1", "team@group.calendar.google.com", "Team", "#33b679");
+        cal.access_role = "reader".to_string();
+        cal.sort_order = 3;
+
+        db.upsert_calendars(std::slice::from_ref(&cal)).expect("upsert");
+        let listed = db.list_calendars("acc1").expect("list");
+
+        assert_eq!(listed, vec![cal]);
+    }
+
+    #[test]
+    fn list_is_scoped_to_the_account() {
+        let db = test_db();
+        db.upsert_calendars(&[
+            calendar("acc1", "primary", "Mine", "#039be5"),
+            calendar("acc2", "primary", "Theirs", "#d50000"),
+        ])
+        .expect("upsert");
+
+        let listed = db.list_calendars("acc1").expect("list");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "Mine");
+    }
+
+    #[test]
+    fn list_puts_the_primary_calendar_first() {
+        let db = test_db();
+        let mut shared = calendar("acc1", "shared@group.calendar.google.com", "Shared", "#0b8043");
+        shared.sort_order = 0;
+        let mut primary = calendar("acc1", "primary", "Personal", "#039be5");
+        primary.sort_order = 9; // provider order would otherwise put it last
+        db.upsert_calendars(&[shared, primary]).expect("upsert");
+
+        let listed = db.list_calendars("acc1").expect("list");
+
+        assert_eq!(listed[0].provider_calendar_id, "primary");
+    }
+
+    #[test]
+    fn resync_refreshes_provider_fields() {
+        let db = test_db();
+        db.upsert_calendars(&[calendar("acc1", "primary", "Old name", "#039be5")])
+            .expect("first sync");
+
+        let mut renamed = calendar("acc1", "primary", "New name", "#d50000");
+        renamed.updated_at = 2_000;
+        db.upsert_calendars(&[renamed]).expect("resync");
+
+        let listed = db.list_calendars("acc1").expect("list");
+        assert_eq!(listed.len(), 1, "a resync updates in place, never duplicates");
+        assert_eq!(listed[0].name, "New name");
+        assert_eq!(listed[0].color, "#d50000");
+    }
+
+    #[test]
+    fn resync_preserves_the_users_hidden_toggle() {
+        // The whole point of a local visibility flag: syncing the calendar
+        // list every 5 minutes must not keep un-hiding what the user hid.
+        let db = test_db();
+        db.upsert_calendars(&[calendar(
+            "acc1",
+            "holidays@group.v.calendar.google.com",
+            "Holidays",
+            "#0b8043",
+        )])
+        .expect("first sync");
+        db.set_calendar_visible("acc1", "holidays@group.v.calendar.google.com", false)
+            .expect("hide");
+
+        db.upsert_calendars(&[calendar(
+            "acc1",
+            "holidays@group.v.calendar.google.com",
+            "Holidays",
+            "#0b8043",
+        )])
+        .expect("resync");
+
+        let listed = db.list_calendars("acc1").expect("list");
+        assert!(!listed[0].is_visible, "sync must not reset the user's hide toggle");
+    }
+
+    #[test]
+    fn set_calendar_visible_is_scoped_to_the_account() {
+        let db = test_db();
+        db.upsert_calendars(&[
+            calendar("acc1", "primary", "Mine", "#039be5"),
+            calendar("acc2", "primary", "Theirs", "#d50000"),
+        ])
+        .expect("upsert");
+
+        db.set_calendar_visible("acc1", "primary", false).expect("hide");
+
+        assert!(!db.list_calendars("acc1").expect("list")[0].is_visible);
+        assert!(db.list_calendars("acc2").expect("list")[0].is_visible);
+    }
+
+    #[test]
+    fn delete_calendars_not_in_drops_only_the_missing_ones() {
+        let db = test_db();
+        db.upsert_calendars(&[
+            calendar("acc1", "primary", "Personal", "#039be5"),
+            calendar("acc1", "team@group.calendar.google.com", "Team", "#33b679"),
+            calendar("acc2", "primary", "Other account", "#d50000"),
+        ])
+        .expect("upsert");
+
+        db.delete_calendars_not_in("acc1", &["primary".to_string()])
+            .expect("sweep");
+
+        let acc1 = db.list_calendars("acc1").expect("list");
+        assert_eq!(acc1.len(), 1);
+        assert_eq!(acc1[0].provider_calendar_id, "primary");
+        assert_eq!(
+            db.list_calendars("acc2").expect("list").len(),
+            1,
+            "other accounts untouched"
+        );
+    }
+
+    #[test]
+    fn delete_calendars_not_in_with_no_live_ids_clears_the_account() {
+        let db = test_db();
+        db.upsert_calendars(&[calendar("acc1", "primary", "Personal", "#039be5")])
+            .expect("upsert");
+
+        db.delete_calendars_not_in("acc1", &[]).expect("sweep");
+
+        assert!(db.list_calendars("acc1").expect("list").is_empty());
+    }
+}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -13,6 +13,7 @@ mod embedded {
 pub mod accounts;
 pub mod attachments;
 pub mod calendar;
+pub mod calendars;
 pub mod chat;
 pub mod drafts;
 pub mod emails;
@@ -883,6 +884,7 @@ mod schema_parity_tests {
             "smart_filter_suggestions",
             "calendar_events",
             "calendar_sync_state",
+            "calendars",
         ] {
             assert!(
                 tables.iter().any(|t| t == required),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -510,6 +510,8 @@ pub fn run() {
             commands::search::get_ai_model,
             commands::search::set_ai_model,
             commands::calendar::get_calendar_events,
+            commands::calendar::get_calendars,
+            commands::calendar::set_calendar_visible,
             commands::calendar::create_calendar_event,
             commands::calendar::delete_calendar_event,
             commands::calendar::get_calendar_invite,

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -169,6 +169,30 @@ fn default_attendee_response() -> String {
     "needsAction".to_string()
 }
 
+/// One calendar an account can see: its own calendars plus any shared with it
+/// or subscribed to. Refreshed from the provider on every sync (Google
+/// `calendarList.list` / Graph `/me/calendars`) — except `is_visible`, which is
+/// the user's local show/hide toggle and survives sync.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(TS), ts(export, export_to = "../src/types/generated/"))]
+#[serde(rename_all = "camelCase")]
+pub struct Calendar {
+    pub id: String,
+    pub account_id: String,
+    pub provider_calendar_id: String,
+    pub name: String,
+    /// Provider colour as "#rrggbb"; empty when the provider reported none —
+    /// the UI then falls back to a deterministic palette slot.
+    pub color: String,
+    pub is_primary: bool,
+    /// "owner" | "writer" | "reader" | "freeBusyReader"
+    pub access_role: String,
+    pub is_visible: bool,
+    pub sort_order: i64,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
 /// One calendar event instance synced from the provider. Recurring events are
 /// stored as expanded instances (one row per occurrence in the sync window),
 /// never as RRULE masters — see `migrations/V011__calendar_events.sql`.

--- a/src-tauri/src/services/calendar/create.rs
+++ b/src-tauri/src/services/calendar/create.rs
@@ -53,6 +53,18 @@ pub fn validate_new_event(input: &NewCalendarEvent) -> Result<()> {
     Ok(())
 }
 
+/// The account's primary calendar id, falling back to the provider's
+/// `"primary"` alias when the registry has not been populated yet (an event
+/// created before the first calendar sync completes).
+fn primary_calendar_id(db: &Database, account_id: &str) -> Result<String> {
+    Ok(db
+        .list_calendars(account_id)?
+        .into_iter()
+        .find(|c| c.is_primary)
+        .map(|c| c.provider_calendar_id)
+        .unwrap_or_else(|| "primary".to_string()))
+}
+
 /// Create the event on the provider's primary calendar, store the returned
 /// instance locally, and hand it back for immediate rendering.
 pub async fn create_calendar_event(
@@ -64,7 +76,12 @@ pub async fn create_calendar_event(
 ) -> Result<CalendarEvent> {
     validate_new_event(&input)?;
     let created = provider.create_event(&input).await?;
-    let rows = plan_event_rows(account_id, std::slice::from_ref(&created), now);
+    // Store the primary calendar's real provider id, not the "primary" alias
+    // the create call uses: the registry is keyed by the real id, so the alias
+    // would break the colour lookup and let the next sync insert a duplicate
+    // row for the same event under a different calendar_id.
+    let calendar_id = primary_calendar_id(db, account_id)?;
+    let rows = plan_event_rows(account_id, &calendar_id, std::slice::from_ref(&created), now);
     let row = rows
         .into_iter()
         .next()

--- a/src-tauri/src/services/calendar/delete.rs
+++ b/src-tauri/src/services/calendar/delete.rs
@@ -29,38 +29,40 @@ impl DeleteScope {
     }
 }
 
+#[allow(clippy::too_many_arguments)] // one argument per provider call parameter
 pub async fn delete_calendar_event(
     db: &Database,
     account_id: &str,
     provider: &dyn CalendarProvider,
+    calendar_id: &str,
     provider_event_id: &str,
     scope: DeleteScope,
     notify_attendees: bool,
     cancellation_message: &str,
 ) -> Result<()> {
     let event = db
-        .get_calendar_event_by_provider_id(account_id, provider_event_id)?
+        .get_calendar_event_by_provider_id(account_id, calendar_id, provider_event_id)?
         .ok_or_else(|| AppError::NotFound(format!("calendar event '{provider_event_id}' not found")))?;
 
     match (scope, event.recurring_event_id.as_deref()) {
         // Non-recurring events: every scope collapses to a plain delete.
         (_, None) | (DeleteScope::Instance, Some(_)) => {
             provider
-                .delete_event(provider_event_id, notify_attendees, cancellation_message)
+                .delete_event(calendar_id, provider_event_id, notify_attendees, cancellation_message)
                 .await?;
-            db.delete_calendar_event(account_id, provider_event_id)?;
+            db.delete_calendar_event(account_id, calendar_id, provider_event_id)?;
         }
         (DeleteScope::All, Some(master_id)) => {
             provider
-                .delete_event(master_id, notify_attendees, cancellation_message)
+                .delete_event(calendar_id, master_id, notify_attendees, cancellation_message)
                 .await?;
-            db.delete_calendar_events_for_master(account_id, master_id)?;
+            db.delete_calendar_events_for_master(account_id, calendar_id, master_id)?;
         }
         (DeleteScope::Following, Some(master_id)) => {
             provider
-                .truncate_recurring_event(master_id, event.start_time, notify_attendees)
+                .truncate_recurring_event(calendar_id, master_id, event.start_time, notify_attendees)
                 .await?;
-            db.delete_calendar_events_for_master_from(account_id, master_id, event.start_time)?;
+            db.delete_calendar_events_for_master_from(account_id, calendar_id, master_id, event.start_time)?;
         }
     }
     Ok(())
@@ -74,7 +76,7 @@ mod tests {
 
     fn base_event(id: &str, start: i64) -> CalendarEvent {
         CalendarEvent {
-            id: format!("acc1:{id}"),
+            id: format!("acc1:primary:{id}"),
             account_id: "acc1".to_string(),
             provider_event_id: id.to_string(),
             calendar_id: "primary".to_string(),
@@ -128,6 +130,7 @@ mod tests {
             &db,
             "acc1",
             &provider,
+            "primary",
             "ev1",
             DeleteScope::Instance,
             true,
@@ -139,7 +142,12 @@ mod tests {
         let deleted = provider.deleted.lock().expect("lock");
         assert_eq!(
             *deleted,
-            vec![("ev1".to_string(), true, "Moving to next week, sorry!".to_string())]
+            vec![(
+                "primary".to_string(),
+                "ev1".to_string(),
+                true,
+                "Moving to next week, sorry!".to_string()
+            )]
         );
         assert!(db.list_calendar_events("acc1", 0, 10_000).expect("list").is_empty());
     }
@@ -149,12 +157,21 @@ mod tests {
         let db = seeded_db_with_event();
         let provider = FakeCalendarProvider::with_events(vec![]);
 
-        delete_calendar_event(&db, "acc1", &provider, "ev1", DeleteScope::Instance, false, "")
-            .await
-            .expect("delete");
+        delete_calendar_event(
+            &db,
+            "acc1",
+            &provider,
+            "primary",
+            "ev1",
+            DeleteScope::Instance,
+            false,
+            "",
+        )
+        .await
+        .expect("delete");
 
         let deleted = provider.deleted.lock().expect("lock");
-        assert!(!deleted[0].1, "notify flag must pass through as false");
+        assert!(!deleted[0].2, "notify flag must pass through as false");
     }
 
     #[tokio::test]
@@ -162,7 +179,17 @@ mod tests {
         let db = seeded_db_with_event();
         let provider = FakeCalendarProvider::failing("[UNAVAILABLE] delete rejected");
 
-        let result = delete_calendar_event(&db, "acc1", &provider, "ev1", DeleteScope::Instance, true, "").await;
+        let result = delete_calendar_event(
+            &db,
+            "acc1",
+            &provider,
+            "primary",
+            "ev1",
+            DeleteScope::Instance,
+            true,
+            "",
+        )
+        .await;
 
         assert!(result.is_err());
         assert_eq!(
@@ -177,13 +204,22 @@ mod tests {
         let db = seeded_db_with_series();
         let provider = FakeCalendarProvider::with_events(vec![]);
 
-        delete_calendar_event(&db, "acc1", &provider, "m_2", DeleteScope::Instance, false, "")
-            .await
-            .expect("delete");
+        delete_calendar_event(
+            &db,
+            "acc1",
+            &provider,
+            "primary",
+            "m_2",
+            DeleteScope::Instance,
+            false,
+            "",
+        )
+        .await
+        .expect("delete");
 
         let deleted = provider.deleted.lock().expect("lock");
         assert_eq!(
-            deleted[0].0, "m_2",
+            deleted[0].1, "m_2",
             "the instance id, not the master, is deleted upstream"
         );
         let remaining: Vec<String> = db
@@ -200,12 +236,12 @@ mod tests {
         let db = seeded_db_with_series();
         let provider = FakeCalendarProvider::with_events(vec![]);
 
-        delete_calendar_event(&db, "acc1", &provider, "m_2", DeleteScope::All, true, "")
+        delete_calendar_event(&db, "acc1", &provider, "primary", "m_2", DeleteScope::All, true, "")
             .await
             .expect("delete");
 
         let deleted = provider.deleted.lock().expect("lock");
-        assert_eq!(deleted[0].0, "m", "whole-series delete targets the master id");
+        assert_eq!(deleted[0].1, "m", "whole-series delete targets the master id");
         assert!(db.list_calendar_events("acc1", 0, 10_000).expect("list").is_empty());
     }
 
@@ -214,12 +250,21 @@ mod tests {
         let db = seeded_db_with_series();
         let provider = FakeCalendarProvider::with_events(vec![]);
 
-        delete_calendar_event(&db, "acc1", &provider, "m_2", DeleteScope::Following, true, "")
-            .await
-            .expect("delete");
+        delete_calendar_event(
+            &db,
+            "acc1",
+            &provider,
+            "primary",
+            "m_2",
+            DeleteScope::Following,
+            true,
+            "",
+        )
+        .await
+        .expect("delete");
 
         let truncated = provider.truncated.lock().expect("lock");
-        assert_eq!(*truncated, vec![("m".to_string(), 2_000, true)]);
+        assert_eq!(*truncated, vec![("primary".to_string(), "m".to_string(), 2_000, true)]);
         assert!(
             provider.deleted.lock().expect("lock").is_empty(),
             "no plain delete on Following"
@@ -237,7 +282,17 @@ mod tests {
     async fn unknown_event_is_a_not_found_error() {
         let db = seeded_db_with_event();
         let provider = FakeCalendarProvider::with_events(vec![]);
-        let result = delete_calendar_event(&db, "acc1", &provider, "ghost", DeleteScope::Instance, false, "").await;
+        let result = delete_calendar_event(
+            &db,
+            "acc1",
+            &provider,
+            "primary",
+            "ghost",
+            DeleteScope::Instance,
+            false,
+            "",
+        )
+        .await;
         assert!(matches!(result, Err(AppError::NotFound(_))));
     }
 }

--- a/src-tauri/src/services/calendar/sync.rs
+++ b/src-tauri/src/services/calendar/sync.rs
@@ -4,11 +4,12 @@
 //! (`sync_account_calendar`) does the I/O against the [`CalendarProvider`]
 //! seam and the DB. No sync tokens in v1 — see `sync/calendar_provider.rs`.
 
+use crate::db::calendars::calendar_row_id;
 use crate::db::Database;
 use crate::models::error::{AppError, Result};
-use crate::models::CalendarEvent;
+use crate::models::{Calendar, CalendarEvent};
 use crate::services::calendar::meeting_link::extract_meeting_link;
-use crate::sync::calendar_provider::{CalendarProvider, ProviderCalendarEvent};
+use crate::sync::calendar_provider::{CalendarProvider, ProviderCalendar, ProviderCalendarEvent};
 
 /// Rolling sync window: 30 days back (recent context) / 90 days forward
 /// (planning horizon). ~120 days of expanded instances is a few hundred
@@ -21,20 +22,52 @@ pub fn sync_window(now: i64) -> (i64, i64) {
     (now - CALENDAR_WINDOW_PAST_SECS, now + CALENDAR_WINDOW_FUTURE_SECS)
 }
 
-/// Pure planner: provider events → DB rows. Cancelled instances are dropped;
-/// the stale sweep removes their previously-synced rows. Meeting links are
-/// extracted here (structured URLs first, then location/description text).
-pub fn plan_event_rows(account_id: &str, fetched: &[ProviderCalendarEvent], now: i64) -> Vec<CalendarEvent> {
+/// Pure planner: provider calendars → DB rows. `is_visible` is seeded from the
+/// provider's own "shown in my UI" flag, which only matters on first insert —
+/// the upsert never overwrites it afterwards, so the user's toggle wins from
+/// then on.
+pub fn plan_calendar_rows(account_id: &str, fetched: &[ProviderCalendar], now: i64) -> Vec<Calendar> {
+    fetched
+        .iter()
+        .enumerate()
+        .map(|(index, c)| Calendar {
+            id: calendar_row_id(account_id, &c.provider_calendar_id),
+            account_id: account_id.to_string(),
+            provider_calendar_id: c.provider_calendar_id.clone(),
+            name: c.name.clone(),
+            color: c.color.clone(),
+            is_primary: c.is_primary,
+            access_role: c.access_role.clone(),
+            is_visible: c.selected,
+            sort_order: index as i64,
+            created_at: now,
+            updated_at: now,
+        })
+        .collect()
+}
+
+/// Pure planner: provider events → DB rows for one calendar. Cancelled
+/// instances are dropped; the stale sweep removes their previously-synced
+/// rows. Meeting links are extracted here (structured URLs first, then
+/// location/description text).
+pub fn plan_event_rows(
+    account_id: &str,
+    calendar_id: &str,
+    fetched: &[ProviderCalendarEvent],
+    now: i64,
+) -> Vec<CalendarEvent> {
     fetched
         .iter()
         .filter(|e| e.status != "cancelled")
         .map(|e| {
             let link = extract_meeting_link(&e.structured_meeting_urls, &e.location, &e.description);
             CalendarEvent {
-                id: format!("{account_id}:{}", e.provider_event_id),
+                // The calendar segment is load-bearing: providers reuse one
+                // event id across every calendar an event is visible in.
+                id: format!("{account_id}:{calendar_id}:{}", e.provider_event_id),
                 account_id: account_id.to_string(),
                 provider_event_id: e.provider_event_id.clone(),
-                calendar_id: "primary".to_string(),
+                calendar_id: calendar_id.to_string(),
                 title: e.title.clone(),
                 description: e.description.clone(),
                 location: e.location.clone(),
@@ -57,7 +90,27 @@ pub fn plan_event_rows(account_id: &str, fetched: &[ProviderCalendarEvent], now:
         .collect()
 }
 
-/// One full sync cycle for one account. Returns the number of events stored.
+/// Prefer an account-wide auth/permission failure over an incidental one, so
+/// the scheduler still sees the signal it auto-disables the integration on.
+fn most_actionable(errors: Vec<AppError>) -> Option<AppError> {
+    let mut fallback = None;
+    for error in errors {
+        match error {
+            e @ (AppError::CalendarPermissionDenied { .. } | AppError::NeedsReauth { .. }) => return Some(e),
+            other => fallback.get_or_insert(other),
+        };
+    }
+    fallback
+}
+
+/// One full sync cycle for one account, across every calendar it can see.
+/// Returns the number of events stored.
+///
+/// A single calendar that fails (sharing revoked, provider hiccup on one
+/// shared calendar) is logged and skipped: its stored events are left exactly
+/// as they were rather than swept, and the other calendars still sync. Only a
+/// failure that affects *every* calendar propagates — that is the account-wide
+/// problem the scheduler acts on.
 pub async fn sync_account_calendar(
     db: &Database,
     account_id: &str,
@@ -65,10 +118,58 @@ pub async fn sync_account_calendar(
     now: i64,
 ) -> Result<u32> {
     let (window_start, window_end) = sync_window(now);
-    let fetched = provider.list_events(window_start, window_end).await?;
-    let rows = plan_event_rows(account_id, &fetched, now);
+
+    // The calendar list is the one fetch that must succeed: everything below
+    // is scoped by it, and treating a failed list as "no calendars" would
+    // delete the entire local mirror.
+    let fetched_calendars = provider.list_calendars().await?;
+    db.upsert_calendars(&plan_calendar_rows(account_id, &fetched_calendars, now))?;
+    let live_ids: Vec<String> = fetched_calendars
+        .iter()
+        .map(|c| c.provider_calendar_id.clone())
+        .collect();
+    db.delete_calendars_not_in(account_id, &live_ids)?;
+    db.delete_calendar_events_not_in(account_id, &live_ids)?;
+
+    let mut rows = Vec::new();
+    let mut synced_ids: Vec<String> = Vec::new();
+    let mut failures: Vec<AppError> = Vec::new();
+    for calendar in &fetched_calendars {
+        match provider
+            .list_events(&calendar.provider_calendar_id, window_start, window_end)
+            .await
+        {
+            Ok(fetched) => {
+                rows.extend(plan_event_rows(
+                    account_id,
+                    &calendar.provider_calendar_id,
+                    &fetched,
+                    now,
+                ));
+                synced_ids.push(calendar.provider_calendar_id.clone());
+            }
+            Err(e) => {
+                crate::services::logger::log(
+                    "error",
+                    "sync",
+                    format!("calendar: skipping \"{}\" this cycle: {e}", calendar.name),
+                );
+                failures.push(e);
+            }
+        }
+    }
+
+    // Every calendar failed → the cause is account-wide (expired token, scope
+    // never granted), not a per-calendar quirk. Surface it so the scheduler
+    // can re-auth or auto-disable instead of silently reporting 0 events.
+    if synced_ids.is_empty() && !failures.is_empty() {
+        if let Some(error) = most_actionable(failures) {
+            return Err(error);
+        }
+    }
+
     db.upsert_calendar_events(&rows)?;
-    db.delete_stale_calendar_events(account_id, window_start, window_end, now)?;
+    db.delete_stale_calendar_events(account_id, &synced_ids, window_start, window_end, now)?;
     db.set_calendar_sync_token(account_id, None, now)?;
     Ok(rows.len() as u32)
 }
@@ -137,9 +238,9 @@ mod tests {
 
     #[test]
     fn plans_rows_with_stable_ids_and_run_timestamps() {
-        let rows = plan_event_rows("acc1", &[provider_event("ev1", 100, 200)], 5_000);
+        let rows = plan_event_rows("acc1", "primary", &[provider_event("ev1", 100, 200)], 5_000);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].id, "acc1:ev1");
+        assert_eq!(rows[0].id, "acc1:primary:ev1");
         assert_eq!(rows[0].account_id, "acc1");
         assert_eq!(rows[0].updated_at, 5_000);
         assert_eq!(rows[0].notified_at, None);
@@ -149,7 +250,7 @@ mod tests {
     fn cancelled_events_are_dropped_from_the_plan() {
         let mut cancelled = provider_event("gone", 100, 200);
         cancelled.status = "cancelled".to_string();
-        let rows = plan_event_rows("acc1", &[cancelled, provider_event("kept", 300, 400)], 5_000);
+        let rows = plan_event_rows("acc1", "primary", &[cancelled, provider_event("kept", 300, 400)], 5_000);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].provider_event_id, "kept");
     }
@@ -158,7 +259,7 @@ mod tests {
     fn plan_extracts_meeting_link_from_structured_urls() {
         let mut event = provider_event("ev1", 100, 200);
         event.structured_meeting_urls = vec!["https://meet.google.com/abc-defg-hij".to_string()];
-        let rows = plan_event_rows("acc1", &[event], 5_000);
+        let rows = plan_event_rows("acc1", "primary", &[event], 5_000);
         assert_eq!(
             rows[0].meeting_link.as_deref(),
             Some("https://meet.google.com/abc-defg-hij")
@@ -170,13 +271,13 @@ mod tests {
     fn plan_extracts_meeting_link_from_location_text() {
         let mut event = provider_event("ev1", 100, 200);
         event.location = "https://acme.webex.com/meet/jdoe".to_string();
-        let rows = plan_event_rows("acc1", &[event], 5_000);
+        let rows = plan_event_rows("acc1", "primary", &[event], 5_000);
         assert_eq!(rows[0].meeting_platform.as_deref(), Some("webex"));
     }
 
     #[test]
     fn plan_leaves_meeting_link_none_when_nothing_found() {
-        let rows = plan_event_rows("acc1", &[provider_event("ev1", 100, 200)], 5_000);
+        let rows = plan_event_rows("acc1", "primary", &[provider_event("ev1", 100, 200)], 5_000);
         assert_eq!(rows[0].meeting_link, None);
         assert_eq!(rows[0].meeting_platform, None);
     }
@@ -216,7 +317,8 @@ mod tests {
         sync_account_calendar(&db, "acc1", &provider, first_run)
             .await
             .expect("first sync");
-        db.mark_calendar_event_notified("acc1:keeps", first_run).expect("mark");
+        db.mark_calendar_event_notified("acc1:primary:keeps", first_run)
+            .expect("mark");
 
         // Second run: upstream deleted one event.
         let second_run = first_run + 300;
@@ -251,6 +353,192 @@ mod tests {
         assert!(result.is_err(), "provider failure must propagate, never be swallowed");
         let events = db.list_calendar_events("acc1", 0, i64::MAX).expect("list");
         assert_eq!(events.len(), 1, "a failed fetch must not wipe local events");
+    }
+
+    // ── multi-calendar ─────────────────────────────────────────────────────
+
+    fn multi_calendar_provider(now: i64) -> FakeCalendarProvider {
+        FakeCalendarProvider::with_calendars(vec![
+            (
+                FakeCalendarProvider::primary_calendar(),
+                vec![provider_event("mine", now + 3_600, now + 7_200)],
+            ),
+            (
+                FakeCalendarProvider::calendar("team@group.calendar.google.com", "Team", "#33b679"),
+                vec![provider_event("theirs", now + 10_000, now + 13_600)],
+            ),
+        ])
+    }
+
+    #[tokio::test]
+    async fn sync_stores_the_calendar_registry() {
+        let db = test_db();
+        let now = 1_000_000;
+
+        sync_account_calendar(&db, "acc1", &multi_calendar_provider(now), now)
+            .await
+            .expect("sync");
+
+        let calendars = db.list_calendars("acc1").expect("list calendars");
+        assert_eq!(calendars.len(), 2);
+        assert_eq!(calendars[0].provider_calendar_id, "primary");
+        assert_eq!(calendars[1].name, "Team");
+        assert_eq!(calendars[1].color, "#33b679");
+    }
+
+    #[tokio::test]
+    async fn sync_stores_events_from_every_calendar_tagged_with_their_own() {
+        let db = test_db();
+        let now = 1_000_000;
+
+        let stored = sync_account_calendar(&db, "acc1", &multi_calendar_provider(now), now)
+            .await
+            .expect("sync");
+
+        assert_eq!(stored, 2);
+        let events = db.list_calendar_events("acc1", 0, i64::MAX).expect("list");
+        let mut tagged: Vec<(&str, &str)> = events
+            .iter()
+            .map(|e| (e.provider_event_id.as_str(), e.calendar_id.as_str()))
+            .collect();
+        tagged.sort_unstable();
+        assert_eq!(
+            tagged,
+            vec![("mine", "primary"), ("theirs", "team@group.calendar.google.com")]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_calendar_hidden_by_the_user_still_syncs() {
+        // Visibility is a render-time filter, so re-showing a calendar is
+        // instant instead of waiting for the next 5-minute poll.
+        let db = test_db();
+        let now = 1_000_000;
+        sync_account_calendar(&db, "acc1", &multi_calendar_provider(now), now)
+            .await
+            .expect("first sync");
+        db.set_calendar_visible("acc1", "team@group.calendar.google.com", false)
+            .expect("hide");
+
+        sync_account_calendar(&db, "acc1", &multi_calendar_provider(now), now + 300)
+            .await
+            .expect("second sync");
+
+        let events = db.list_calendar_events("acc1", 0, i64::MAX).expect("list");
+        assert_eq!(events.len(), 2, "hidden calendars keep syncing in the background");
+        assert!(!db
+            .list_calendars("acc1")
+            .expect("list")
+            .iter()
+            .any(|c| c.provider_calendar_id == "team@group.calendar.google.com" && c.is_visible));
+    }
+
+    #[tokio::test]
+    async fn one_failing_calendar_does_not_sweep_its_events_or_block_the_others() {
+        let db = test_db();
+        let now = 1_000_000;
+        sync_account_calendar(&db, "acc1", &multi_calendar_provider(now), now)
+            .await
+            .expect("seed sync");
+
+        // Next cycle: the shared calendar errors, the primary still works.
+        let flaky = multi_calendar_provider(now).failing_calendar("team@group.calendar.google.com");
+        let stored = sync_account_calendar(&db, "acc1", &flaky, now + 300)
+            .await
+            .expect("a single bad calendar must not fail the whole sync");
+
+        assert_eq!(stored, 1, "only the healthy calendar contributed rows");
+        let events = db.list_calendar_events("acc1", 0, i64::MAX).expect("list");
+        assert_eq!(
+            events.len(),
+            2,
+            "the failing calendar's events are left alone, not swept"
+        );
+    }
+
+    #[tokio::test]
+    async fn when_every_calendar_fails_the_permission_error_propagates() {
+        // The scheduler auto-disables the integration on
+        // CalendarPermissionDenied — swallowing it would strand the user with
+        // a calendar that silently reports zero events forever.
+        let db = test_db();
+        let now = 1_000_000;
+        let provider = multi_calendar_provider(now)
+            .failing_calendar("primary")
+            .failing_calendar("team@group.calendar.google.com");
+
+        let result = sync_account_calendar(&db, "acc1", &provider, now).await;
+
+        assert!(result.is_err(), "an account-wide failure must propagate");
+    }
+
+    #[tokio::test]
+    async fn losing_access_to_a_calendar_drops_it_and_its_events() {
+        let db = test_db();
+        let now = 1_000_000;
+        sync_account_calendar(&db, "acc1", &multi_calendar_provider(now), now)
+            .await
+            .expect("seed sync");
+
+        // The shared calendar disappears from the provider's list entirely.
+        let only_primary = FakeCalendarProvider::with_events(vec![provider_event("mine", now + 3_600, now + 7_200)]);
+        sync_account_calendar(&db, "acc1", &only_primary, now + 300)
+            .await
+            .expect("sync");
+
+        assert_eq!(db.list_calendars("acc1").expect("list").len(), 1);
+        let events = db.list_calendar_events("acc1", 0, i64::MAX).expect("list");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].calendar_id, "primary");
+    }
+
+    #[tokio::test]
+    async fn the_same_event_in_two_calendars_is_kept_as_two_rows() {
+        // Google hands out one id per meeting, repeated in every calendar it
+        // shows up in. Both copies must survive so hiding one calendar hides
+        // exactly one of them.
+        let db = test_db();
+        let now = 1_000_000;
+        let provider = FakeCalendarProvider::with_calendars(vec![
+            (
+                FakeCalendarProvider::primary_calendar(),
+                vec![provider_event("shared-ev", now + 3_600, now + 7_200)],
+            ),
+            (
+                FakeCalendarProvider::calendar("team@group.calendar.google.com", "Team", "#33b679"),
+                vec![provider_event("shared-ev", now + 3_600, now + 7_200)],
+            ),
+        ]);
+
+        let stored = sync_account_calendar(&db, "acc1", &provider, now).await.expect("sync");
+
+        assert_eq!(stored, 2);
+        assert_eq!(db.list_calendar_events("acc1", 0, i64::MAX).expect("list").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_calendar_the_provider_hides_starts_hidden() {
+        let db = test_db();
+        let now = 1_000_000;
+        let mut unselected =
+            FakeCalendarProvider::calendar("holidays@group.v.calendar.google.com", "Holidays", "#0b8043");
+        unselected.selected = false;
+        let provider = FakeCalendarProvider::with_calendars(vec![
+            (FakeCalendarProvider::primary_calendar(), vec![]),
+            (unselected, vec![]),
+        ]);
+
+        sync_account_calendar(&db, "acc1", &provider, now).await.expect("sync");
+
+        let calendars = db.list_calendars("acc1").expect("list");
+        let holidays = calendars
+            .iter()
+            .find(|c| c.provider_calendar_id == "holidays@group.v.calendar.google.com")
+            .expect("holidays calendar");
+        assert!(
+            !holidays.is_visible,
+            "a calendar the user already hid in the provider's UI should not appear unbidden"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/chat/tools/list_calendar_events.rs
+++ b/src-tauri/src/services/chat/tools/list_calendar_events.rs
@@ -139,7 +139,7 @@ impl Tool for ListCalendarEventsTool {
             ));
         }
         let (start, end) = resolve_window(&args, chrono::Utc::now().timestamp());
-        let events = match ctx.db.list_calendar_events(ctx.account_id, start, end) {
+        let events = match ctx.db.list_visible_calendar_events(ctx.account_id, start, end) {
             Ok(events) => events,
             Err(e) => return Ok(ToolOutput::text(format!("Calendar error: {e}"))),
         };

--- a/src-tauri/src/services/sync_scheduler.rs
+++ b/src-tauri/src/services/sync_scheduler.rs
@@ -580,7 +580,7 @@ async fn meeting_notification_loop(db: Arc<Database>, app: AppHandle, stop_flag:
                 calendar_enabled_or_log(&db, id)
             });
         for account in accounts {
-            let events = match db.list_calendar_events(&account.id, now, now + lead_secs + 60) {
+            let events = match db.list_visible_calendar_events(&account.id, now, now + lead_secs + 60) {
                 Ok(events) => events,
                 Err(e) => {
                     crate::services::logger::log(

--- a/src-tauri/src/sync/calendar_provider.rs
+++ b/src-tauri/src/sync/calendar_provider.rs
@@ -19,6 +19,25 @@ pub fn provider_supports_calendar(provider: &str) -> bool {
     matches!(provider, "gmail" | "outlook")
 }
 
+/// A provider-neutral calendar the account can see: its own calendars, plus
+/// any shared with it or subscribed to. Sourced from Google
+/// `calendarList.list` and Graph `/me/calendars`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderCalendar {
+    pub provider_calendar_id: String,
+    pub name: String,
+    /// Provider colour as "#rrggbb"; empty when the provider reported none.
+    pub color: String,
+    pub is_primary: bool,
+    /// "owner" | "writer" | "reader" | "freeBusyReader" — Graph is mapped onto
+    /// the same set (`canEdit` → writer, otherwise reader).
+    pub access_role: String,
+    /// Whether the provider's own UI currently shows this calendar. Seeds the
+    /// local visibility toggle the first time we see the calendar and is
+    /// ignored afterwards (the user's choice wins from then on).
+    pub selected: bool,
+}
+
 /// A provider-neutral calendar event instance, already expanded (one value per
 /// occurrence). Times are UTC epoch seconds.
 #[derive(Debug, Clone, PartialEq)]
@@ -102,25 +121,41 @@ pub struct NewCalendarEvent {
 
 #[async_trait]
 pub trait CalendarProvider: Send + Sync {
-    /// Every event instance overlapping `[window_start, window_end)`,
-    /// recurrences expanded. Cancelled instances may be included (callers
-    /// filter on `status`).
-    async fn list_events(&self, window_start: i64, window_end: i64) -> Result<Vec<ProviderCalendarEvent>>;
+    /// Every calendar the account can see, in the provider's own list order.
+    async fn list_calendars(&self) -> Result<Vec<ProviderCalendar>>;
+
+    /// Every event instance in `calendar_id` overlapping
+    /// `[window_start, window_end)`, recurrences expanded. Cancelled instances
+    /// may be included (callers filter on `status`).
+    async fn list_events(
+        &self,
+        calendar_id: &str,
+        window_start: i64,
+        window_end: i64,
+    ) -> Result<Vec<ProviderCalendarEvent>>;
 
     /// Create an event on the primary calendar and return it as the provider
     /// now sees it (id assigned, conference link attached when requested).
+    /// Creating into a secondary calendar is deliberately not offered.
     async fn create_event(&self, event: &NewCalendarEvent) -> Result<ProviderCalendarEvent>;
 
-    /// Delete (cancel) an event. When `notify` is true, attendees receive a
-    /// cancellation; `message` rides along where the provider supports it
-    /// (Graph `/cancel` comment — Google's API only sends its standard
-    /// cancellation email, so the message is ignored there).
-    async fn delete_event(&self, provider_event_id: &str, notify: bool, message: &str) -> Result<()>;
+    /// Delete (cancel) an event from `calendar_id`. When `notify` is true,
+    /// attendees receive a cancellation; `message` rides along where the
+    /// provider supports it (Graph `/cancel` comment — Google's API only sends
+    /// its standard cancellation email, so the message is ignored there).
+    async fn delete_event(&self, calendar_id: &str, provider_event_id: &str, notify: bool, message: &str)
+        -> Result<()>;
 
     /// End a recurring series just before `first_removed_start` ("delete this
     /// and following events"): occurrences from that instant on stop existing,
     /// earlier ones survive.
-    async fn truncate_recurring_event(&self, master_id: &str, first_removed_start: i64, notify: bool) -> Result<()>;
+    async fn truncate_recurring_event(
+        &self,
+        calendar_id: &str,
+        master_id: &str,
+        first_removed_start: i64,
+        notify: bool,
+    ) -> Result<()>;
 
     /// RSVP to an invitation identified by its iCalendar UID (from the
     /// invite's .ics). `self_email` is the account's own address — the
@@ -165,28 +200,39 @@ impl RsvpResponse {
     }
 }
 
+/// The calendar id every single-calendar test fixture uses.
+#[cfg(any(test, debug_assertions))]
+pub const FAKE_PRIMARY_CALENDAR: &str = "primary";
+
 /// In-memory fake for service tests. Returns the configured events (filtered
 /// to the requested window) or the configured error, and records created
 /// events so tests can assert on them.
 #[cfg(any(test, debug_assertions))]
 pub struct FakeCalendarProvider {
-    pub events: Vec<ProviderCalendarEvent>,
+    pub calendars: Vec<ProviderCalendar>,
+    /// Events per `provider_calendar_id`.
+    pub events_by_calendar: std::collections::HashMap<String, Vec<ProviderCalendarEvent>>,
     pub error: Option<String>,
+    /// Calendars whose `list_events` fails, so tests can exercise the
+    /// per-calendar failure isolation without failing the whole sync.
+    pub failing_calendars: std::collections::HashSet<String>,
     pub created: std::sync::Mutex<Vec<NewCalendarEvent>>,
-    /// `(provider_event_id, notify, message)` per delete call.
-    pub deleted: std::sync::Mutex<Vec<(String, bool, String)>>,
-    /// `(master_id, first_removed_start, notify)` per truncate call.
-    pub truncated: std::sync::Mutex<Vec<(String, i64, bool)>>,
+    /// `(calendar_id, provider_event_id, notify, message)` per delete call.
+    pub deleted: std::sync::Mutex<Vec<(String, String, bool, String)>>,
+    /// `(calendar_id, master_id, first_removed_start, notify)` per truncate call.
+    pub truncated: std::sync::Mutex<Vec<(String, String, i64, bool)>>,
     /// `(ical_uid, google_status, self_email)` per RSVP call.
     pub rsvps: std::sync::Mutex<Vec<(String, String, String)>>,
 }
 
 #[cfg(any(test, debug_assertions))]
 impl FakeCalendarProvider {
-    pub fn with_events(events: Vec<ProviderCalendarEvent>) -> Self {
+    fn empty() -> Self {
         Self {
-            events,
+            calendars: Vec::new(),
+            events_by_calendar: std::collections::HashMap::new(),
             error: None,
+            failing_calendars: std::collections::HashSet::new(),
             created: std::sync::Mutex::new(Vec::new()),
             deleted: std::sync::Mutex::new(Vec::new()),
             truncated: std::sync::Mutex::new(Vec::new()),
@@ -194,31 +240,87 @@ impl FakeCalendarProvider {
         }
     }
 
-    pub fn failing(message: &str) -> Self {
-        Self {
-            events: Vec::new(),
-            error: Some(message.to_string()),
-            created: std::sync::Mutex::new(Vec::new()),
-            deleted: std::sync::Mutex::new(Vec::new()),
-            truncated: std::sync::Mutex::new(Vec::new()),
-            rsvps: std::sync::Mutex::new(Vec::new()),
+    /// A single primary calendar holding `events` — the shape most tests want.
+    pub fn with_events(events: Vec<ProviderCalendarEvent>) -> Self {
+        Self::with_calendars(vec![(Self::primary_calendar(), events)])
+    }
+
+    /// Several calendars, each with its own events.
+    pub fn with_calendars(calendars: Vec<(ProviderCalendar, Vec<ProviderCalendarEvent>)>) -> Self {
+        let mut fake = Self::empty();
+        for (calendar, events) in calendars {
+            fake.events_by_calendar
+                .insert(calendar.provider_calendar_id.clone(), events);
+            fake.calendars.push(calendar);
         }
+        fake
+    }
+
+    /// Fixture calendar with sensible defaults.
+    pub fn calendar(provider_calendar_id: &str, name: &str, color: &str) -> ProviderCalendar {
+        ProviderCalendar {
+            provider_calendar_id: provider_calendar_id.to_string(),
+            name: name.to_string(),
+            color: color.to_string(),
+            is_primary: provider_calendar_id == FAKE_PRIMARY_CALENDAR,
+            access_role: "owner".to_string(),
+            selected: true,
+        }
+    }
+
+    pub fn primary_calendar() -> ProviderCalendar {
+        Self::calendar(FAKE_PRIMARY_CALENDAR, "Personal", "#039be5")
+    }
+
+    /// Make `list_events` fail for one calendar while the rest succeed.
+    pub fn failing_calendar(mut self, provider_calendar_id: &str) -> Self {
+        self.failing_calendars.insert(provider_calendar_id.to_string());
+        self
+    }
+
+    pub fn failing(message: &str) -> Self {
+        let mut fake = Self::empty();
+        fake.calendars.push(Self::primary_calendar());
+        fake.error = Some(message.to_string());
+        fake
     }
 }
 
 #[cfg(any(test, debug_assertions))]
 #[async_trait]
 impl CalendarProvider for FakeCalendarProvider {
-    async fn list_events(&self, window_start: i64, window_end: i64) -> Result<Vec<ProviderCalendarEvent>> {
+    async fn list_calendars(&self) -> Result<Vec<ProviderCalendar>> {
         if let Some(message) = &self.error {
             return Err(crate::models::error::AppError::SyncError(message.clone()));
         }
+        Ok(self.calendars.clone())
+    }
+
+    async fn list_events(
+        &self,
+        calendar_id: &str,
+        window_start: i64,
+        window_end: i64,
+    ) -> Result<Vec<ProviderCalendarEvent>> {
+        if let Some(message) = &self.error {
+            return Err(crate::models::error::AppError::SyncError(message.clone()));
+        }
+        if self.failing_calendars.contains(calendar_id) {
+            return Err(crate::models::error::AppError::SyncError(format!(
+                "calendar {calendar_id} is unavailable"
+            )));
+        }
         Ok(self
-            .events
-            .iter()
-            .filter(|e| e.start_time < window_end && e.end_time > window_start)
-            .cloned()
-            .collect())
+            .events_by_calendar
+            .get(calendar_id)
+            .map(|events| {
+                events
+                    .iter()
+                    .filter(|e| e.start_time < window_end && e.end_time > window_start)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default())
     }
 
     async fn create_event(&self, event: &NewCalendarEvent) -> Result<ProviderCalendarEvent> {
@@ -256,25 +358,47 @@ impl CalendarProvider for FakeCalendarProvider {
         })
     }
 
-    async fn delete_event(&self, provider_event_id: &str, notify: bool, message: &str) -> Result<()> {
+    async fn delete_event(
+        &self,
+        calendar_id: &str,
+        provider_event_id: &str,
+        notify: bool,
+        message: &str,
+    ) -> Result<()> {
         if let Some(error) = &self.error {
             return Err(crate::models::error::AppError::SyncError(error.clone()));
         }
         self.deleted
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push((provider_event_id.to_string(), notify, message.to_string()));
+            .push((
+                calendar_id.to_string(),
+                provider_event_id.to_string(),
+                notify,
+                message.to_string(),
+            ));
         Ok(())
     }
 
-    async fn truncate_recurring_event(&self, master_id: &str, first_removed_start: i64, notify: bool) -> Result<()> {
+    async fn truncate_recurring_event(
+        &self,
+        calendar_id: &str,
+        master_id: &str,
+        first_removed_start: i64,
+        notify: bool,
+    ) -> Result<()> {
         if let Some(error) = &self.error {
             return Err(crate::models::error::AppError::SyncError(error.clone()));
         }
         self.truncated
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push((master_id.to_string(), first_removed_start, notify));
+            .push((
+                calendar_id.to_string(),
+                master_id.to_string(),
+                first_removed_start,
+                notify,
+            ));
         Ok(())
     }
 

--- a/src-tauri/src/sync/gmail_calendar.rs
+++ b/src-tauri/src/sync/gmail_calendar.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::models::error::{AppError, Result};
-use crate::sync::calendar_provider::{CalendarProvider, ProviderCalendarEvent};
+use crate::sync::calendar_provider::{CalendarProvider, ProviderCalendar, ProviderCalendarEvent};
 use crate::sync::http_retry::{classify_attempt, Attempt, RetryDecision};
 
 const CALENDAR_API_BASE: &str = "https://www.googleapis.com/calendar/v3";
@@ -139,15 +139,55 @@ impl GoogleCalendarClient {
 
 #[async_trait]
 impl CalendarProvider for GoogleCalendarClient {
-    async fn list_events(&self, window_start: i64, window_end: i64) -> Result<Vec<ProviderCalendarEvent>> {
+    async fn list_calendars(&self) -> Result<Vec<ProviderCalendar>> {
+        let mut calendars = Vec::new();
+        let mut page_token: Option<String> = None;
+        loop {
+            let mut url = format!("{}/users/me/calendarList?maxResults=250", self.base_url);
+            if let Some(token) = &page_token {
+                url.push_str(&format!("&pageToken={}", urlencoding::encode(token)));
+            }
+            let response = self.send_get_with_retry(&url, "list calendars").await?;
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let error_text = response.text().await.unwrap_or_default();
+                return Err(crate::sync::calendar_provider::classify_calendar_fetch_error(
+                    "Google",
+                    status,
+                    &error_text,
+                    self.account_id.as_deref(),
+                ));
+            }
+            let page: serde_json::Value = response.json().await?;
+            if let Some(items) = page.get("items").and_then(|v| v.as_array()) {
+                calendars.extend(items.iter().filter_map(parse_google_calendar));
+            }
+            page_token = page
+                .get("nextPageToken")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if page_token.is_none() {
+                break;
+            }
+        }
+        Ok(calendars)
+    }
+
+    async fn list_events(
+        &self,
+        calendar_id: &str,
+        window_start: i64,
+        window_end: i64,
+    ) -> Result<Vec<ProviderCalendarEvent>> {
         let time_min = epoch_to_rfc3339(window_start)?;
         let time_max = epoch_to_rfc3339(window_end)?;
         let mut events = Vec::new();
         let mut page_token: Option<String> = None;
         loop {
             let mut url = format!(
-                "{}/calendars/primary/events?singleEvents=true&maxResults=250&timeMin={}&timeMax={}",
+                "{}/calendars/{}/events?singleEvents=true&maxResults=250&timeMin={}&timeMax={}",
                 self.base_url,
+                urlencoding::encode(calendar_id),
                 urlencoding::encode(&time_min),
                 urlencoding::encode(&time_max),
             );
@@ -202,12 +242,19 @@ impl CalendarProvider for GoogleCalendarClient {
             .ok_or_else(|| AppError::SyncError("Google Calendar returned an unparseable created event".to_string()))
     }
 
-    async fn delete_event(&self, provider_event_id: &str, notify: bool, _message: &str) -> Result<()> {
+    async fn delete_event(
+        &self,
+        calendar_id: &str,
+        provider_event_id: &str,
+        notify: bool,
+        _message: &str,
+    ) -> Result<()> {
         // Google's API sends its standard cancellation email; a custom message
         // is not supported (`_message` intentionally unused).
         let url = format!(
-            "{}/calendars/primary/events/{}?sendUpdates={}",
+            "{}/calendars/{}/events/{}?sendUpdates={}",
             self.base_url,
+            urlencoding::encode(calendar_id),
             urlencoding::encode(provider_event_id),
             if notify { "all" } else { "none" },
         );
@@ -228,12 +275,19 @@ impl CalendarProvider for GoogleCalendarClient {
         ))
     }
 
-    async fn truncate_recurring_event(&self, master_id: &str, first_removed_start: i64, notify: bool) -> Result<()> {
+    async fn truncate_recurring_event(
+        &self,
+        calendar_id: &str,
+        master_id: &str,
+        first_removed_start: i64,
+        notify: bool,
+    ) -> Result<()> {
         // Fetch the master's recurrence, rewrite the RRULEs with an UNTIL just
         // before the first removed occurrence, and PATCH it back.
         let master_url = format!(
-            "{}/calendars/primary/events/{}",
+            "{}/calendars/{}/events/{}",
             self.base_url,
+            urlencoding::encode(calendar_id),
             urlencoding::encode(master_id)
         );
         let response = self.send_get_with_retry(&master_url, "get recurring master").await?;
@@ -343,6 +397,48 @@ impl CalendarProvider for GoogleCalendarClient {
         }
         Ok(())
     }
+}
+
+/// Google `accessRole` values we store. Anything unrecognised degrades to the
+/// least-privileged role rather than failing the sync (the DB column has a
+/// CHECK constraint, so an unknown value would abort the whole batch).
+fn normalize_access_role(raw: &str) -> String {
+    match raw {
+        "owner" | "writer" | "reader" | "freeBusyReader" => raw.to_string(),
+        _ => "reader".to_string(),
+    }
+}
+
+/// Parse one `calendarList` entry. Returns `None` for entries that carry no
+/// usable id, and for calendars the user has removed (`deleted: true`).
+///
+/// Pure so it is unit-testable without HTTP.
+fn parse_google_calendar(raw: &serde_json::Value) -> Option<ProviderCalendar> {
+    let provider_calendar_id = raw.get("id").and_then(|v| v.as_str())?.to_string();
+    if raw.get("deleted").and_then(|v| v.as_bool()).unwrap_or(false) {
+        return None;
+    }
+    // `summaryOverride` is the user's own rename and is what Google's UI shows.
+    let name = raw
+        .get("summaryOverride")
+        .and_then(|v| v.as_str())
+        .or_else(|| raw.get("summary").and_then(|v| v.as_str()))
+        .unwrap_or_default()
+        .to_string();
+    Some(ProviderCalendar {
+        provider_calendar_id,
+        name,
+        color: raw
+            .get("backgroundColor")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        is_primary: raw.get("primary").and_then(|v| v.as_bool()).unwrap_or(false),
+        access_role: normalize_access_role(raw.get("accessRole").and_then(|v| v.as_str()).unwrap_or_default()),
+        // Only an explicit `false` hides a calendar: a missing flag must never
+        // make a calendar silently vanish from the app.
+        selected: raw.get("selected").and_then(|v| v.as_bool()).unwrap_or(true),
+    })
 }
 
 fn epoch_to_rfc3339(epoch_seconds: i64) -> Result<String> {
@@ -576,6 +672,121 @@ fn parse_google_time(time: &serde_json::Value) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_google_calendar ──────────────────────────────────────────────
+
+    #[test]
+    fn parses_a_shared_calendar_with_its_colour_and_access_role() {
+        let raw = serde_json::json!({
+            "id": "team123@group.calendar.google.com",
+            "summary": "Team calendar",
+            "backgroundColor": "#33b679",
+            "foregroundColor": "#000000",
+            "colorId": "8",
+            "selected": true,
+            "accessRole": "reader",
+        });
+
+        let calendar = parse_google_calendar(&raw).expect("parse");
+
+        assert_eq!(calendar.provider_calendar_id, "team123@group.calendar.google.com");
+        assert_eq!(calendar.name, "Team calendar");
+        assert_eq!(calendar.color, "#33b679");
+        assert_eq!(calendar.access_role, "reader");
+        assert!(!calendar.is_primary);
+        assert!(calendar.selected);
+    }
+
+    #[test]
+    fn primary_calendar_is_flagged() {
+        let raw = serde_json::json!({
+            "id": "someone@example.com",
+            "summary": "someone@example.com",
+            "primary": true,
+            "accessRole": "owner",
+        });
+
+        let calendar = parse_google_calendar(&raw).expect("parse");
+
+        assert!(calendar.is_primary);
+        assert_eq!(calendar.access_role, "owner");
+    }
+
+    #[test]
+    fn a_renamed_calendar_uses_the_users_own_name() {
+        // summaryOverride is what Google's own UI shows for a calendar the
+        // user renamed locally.
+        let raw = serde_json::json!({
+            "id": "shared@group.calendar.google.com",
+            "summary": "Original owner's name",
+            "summaryOverride": "What I call it",
+            "accessRole": "reader",
+        });
+
+        assert_eq!(parse_google_calendar(&raw).expect("parse").name, "What I call it");
+    }
+
+    #[test]
+    fn deleted_calendars_are_skipped() {
+        let raw = serde_json::json!({
+            "id": "gone@group.calendar.google.com",
+            "summary": "Removed",
+            "deleted": true,
+            "accessRole": "reader",
+        });
+
+        assert!(parse_google_calendar(&raw).is_none());
+    }
+
+    #[test]
+    fn a_missing_selected_flag_keeps_the_calendar_visible() {
+        // Only an explicit false hides a calendar — a calendar must never
+        // vanish from the app just because the field was omitted.
+        let raw = serde_json::json!({
+            "id": "cal@group.calendar.google.com",
+            "summary": "No selected field",
+            "accessRole": "owner",
+        });
+
+        assert!(parse_google_calendar(&raw).expect("parse").selected);
+    }
+
+    #[test]
+    fn a_calendar_hidden_in_google_starts_hidden() {
+        let raw = serde_json::json!({
+            "id": "holidays@group.v.calendar.google.com",
+            "summary": "Holidays",
+            "selected": false,
+            "accessRole": "reader",
+        });
+
+        assert!(!parse_google_calendar(&raw).expect("parse").selected);
+    }
+
+    #[test]
+    fn an_unknown_access_role_degrades_to_reader() {
+        // The DB column has a CHECK constraint; an unrecognised role must not
+        // abort the whole calendar batch.
+        let raw = serde_json::json!({
+            "id": "cal@group.calendar.google.com",
+            "summary": "Odd",
+            "accessRole": "somethingNew",
+        });
+
+        assert_eq!(parse_google_calendar(&raw).expect("parse").access_role, "reader");
+    }
+
+    #[test]
+    fn a_calendar_without_a_colour_parses_with_an_empty_colour() {
+        let raw = serde_json::json!({ "id": "cal@group.calendar.google.com", "summary": "Plain" });
+
+        assert_eq!(parse_google_calendar(&raw).expect("parse").color, "");
+    }
+
+    #[test]
+    fn an_entry_without_an_id_is_skipped() {
+        assert!(parse_google_calendar(&serde_json::json!({ "summary": "Nameless" })).is_none());
+    }
 
     #[test]
     fn parses_timed_event_with_meet_conference() {

--- a/src-tauri/src/sync/oauth.rs
+++ b/src-tauri/src/sync/oauth.rs
@@ -27,6 +27,11 @@ const GMAIL_SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",
     "https://www.googleapis.com/auth/calendar.events",
+    // Enumerating the account's other and shared calendars (and their colours)
+    // needs `calendarList.list`, which `calendar.events` does not cover.
+    // This is the narrowest scope that grants it — do NOT widen to
+    // `calendar.readonly`, which also grants reading every calendar's contents.
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
 ];
 
 // Microsoft Graph (Outlook / Office 365) OAuth configuration.
@@ -377,6 +382,39 @@ mod tests {
                 .iter()
                 .any(|s| s == "https://www.googleapis.com/auth/calendar.events"),
             "Gmail OAuth must request event read/write access to Google Calendar, got: {:?}",
+            config.scopes
+        );
+    }
+
+    #[test]
+    fn gmail_scopes_include_calendar_list_enumeration() {
+        // `calendar.events` grants event access on a calendar you can already
+        // name, but not `calendarList.list` — without this scope the app can
+        // never discover the user's other or shared calendars.
+        let config = OAuthConfig::gmail();
+        assert!(
+            config
+                .scopes
+                .iter()
+                .any(|s| s == "https://www.googleapis.com/auth/calendar.calendarlist.readonly"),
+            "Gmail OAuth must be able to enumerate the account's calendars, got: {:?}",
+            config.scopes
+        );
+    }
+
+    #[test]
+    fn gmail_scopes_omit_broad_calendar_readonly() {
+        // `calendar.calendarlist.readonly` lists calendars; `calendar.readonly`
+        // would additionally grant reading every calendar's full contents.
+        // Google's verification requires the narrowest scope that works.
+        let config = OAuthConfig::gmail();
+        assert!(
+            !config
+                .scopes
+                .iter()
+                .any(|s| s == "https://www.googleapis.com/auth/calendar.readonly"
+                    || s == "https://www.googleapis.com/auth/calendar"),
+            "a broader calendar scope than needed was requested, got: {:?}",
             config.scopes
         );
     }

--- a/src-tauri/src/sync/outlook_calendar.rs
+++ b/src-tauri/src/sync/outlook_calendar.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::models::error::{AppError, Result};
-use crate::sync::calendar_provider::{CalendarProvider, ProviderCalendarEvent};
+use crate::sync::calendar_provider::{CalendarProvider, ProviderCalendar, ProviderCalendarEvent};
 use crate::sync::http_retry::{classify_attempt, Attempt, RetryDecision};
 
 const GRAPH_API_BASE: &str = "https://graph.microsoft.com/v1.0";
@@ -20,6 +20,9 @@ const INITIAL_BACKOFF_MS: u64 = 1_000;
 /// without a second round-trip.
 const EVENT_SELECT_FIELDS: &str = "id,subject,body,bodyPreview,location,start,end,isAllDay,isCancelled,\
     organizer,attendees,onlineMeeting,onlineMeetingUrl,webLink,originalStartTimeZone";
+
+/// Fields fetched for every calendar in `/me/calendars`.
+const CALENDAR_SELECT_FIELDS: &str = "id,name,hexColor,color,isDefaultCalendar,canEdit,owner";
 
 pub struct OutlookCalendarClient {
     client: Client,
@@ -152,13 +155,49 @@ impl OutlookCalendarClient {
 
 #[async_trait]
 impl CalendarProvider for OutlookCalendarClient {
-    async fn list_events(&self, window_start: i64, window_end: i64) -> Result<Vec<ProviderCalendarEvent>> {
+    async fn list_calendars(&self) -> Result<Vec<ProviderCalendar>> {
+        let mut calendars = Vec::new();
+        let mut url = format!(
+            "{}/me/calendars?$top=100&$select={}",
+            self.base_url, CALENDAR_SELECT_FIELDS
+        );
+        loop {
+            let response = self.send_get_with_retry(&url, "list calendars").await?;
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let error_text = response.text().await.unwrap_or_default();
+                return Err(crate::sync::calendar_provider::classify_calendar_fetch_error(
+                    "Outlook",
+                    status,
+                    &error_text,
+                    self.account_id.as_deref(),
+                ));
+            }
+            let page: serde_json::Value = response.json().await?;
+            if let Some(items) = page.get("value").and_then(|v| v.as_array()) {
+                calendars.extend(items.iter().filter_map(parse_graph_calendar));
+            }
+            match page.get("@odata.nextLink").and_then(|v| v.as_str()) {
+                Some(next) => url = next.to_string(),
+                None => break,
+            }
+        }
+        Ok(calendars)
+    }
+
+    async fn list_events(
+        &self,
+        calendar_id: &str,
+        window_start: i64,
+        window_end: i64,
+    ) -> Result<Vec<ProviderCalendarEvent>> {
         let start = epoch_to_rfc3339(window_start)?;
         let end = epoch_to_rfc3339(window_end)?;
         let mut events = Vec::new();
         let mut url = format!(
-            "{}/me/calendarView?startDateTime={}&endDateTime={}&$top=100&$select={}",
+            "{}/me/calendars/{}/calendarView?startDateTime={}&endDateTime={}&$top=100&$select={}",
             self.base_url,
+            urlencoding::encode(calendar_id),
             urlencoding::encode(&start),
             urlencoding::encode(&end),
             EVENT_SELECT_FIELDS,
@@ -209,7 +248,15 @@ impl CalendarProvider for OutlookCalendarClient {
             .ok_or_else(|| AppError::SyncError("Outlook returned an unparseable created event".to_string()))
     }
 
-    async fn delete_event(&self, provider_event_id: &str, notify: bool, message: &str) -> Result<()> {
+    async fn delete_event(
+        &self,
+        // Graph addresses every event under `/me/events/{id}` regardless of
+        // which calendar holds it, so the calendar is not part of the URL.
+        _calendar_id: &str,
+        provider_event_id: &str,
+        notify: bool,
+        message: &str,
+    ) -> Result<()> {
         // With attendees to notify, Graph's `/cancel` action sends the
         // cancellation and supports an organizer comment; a plain DELETE
         // removes silently.
@@ -240,7 +287,14 @@ impl CalendarProvider for OutlookCalendarClient {
         ))
     }
 
-    async fn truncate_recurring_event(&self, master_id: &str, first_removed_start: i64, _notify: bool) -> Result<()> {
+    async fn truncate_recurring_event(
+        &self,
+        // See `delete_event`: Graph event ids are calendar-independent.
+        _calendar_id: &str,
+        master_id: &str,
+        first_removed_start: i64,
+        _notify: bool,
+    ) -> Result<()> {
         // Graph sends series-change updates to attendees itself; there is no
         // per-call notify switch on PATCH (`_notify` intentionally unused).
         let master_url = format!("{}/me/events/{}", self.base_url, urlencoding::encode(master_id));
@@ -460,6 +514,42 @@ fn epoch_to_graph_datetime(epoch_seconds: i64) -> Result<String> {
         .ok_or_else(|| AppError::InvalidInput(format!("timestamp {epoch_seconds} out of range")))
 }
 
+/// Parse one `/me/calendars` entry. Returns `None` for entries with no id.
+///
+/// Graph exposes a calendar's colour two ways: `hexColor` (an explicit
+/// "#rrggbb", present when the user picked a custom colour) and `color` (a
+/// named preset whose exact rendering is Outlook's, not a documented hex). We
+/// take `hexColor` when it is there and otherwise leave the colour empty so
+/// the UI assigns a palette slot — inventing hexes for the presets would only
+/// produce colours that don't match Outlook anyway.
+///
+/// Pure so it is unit-testable without HTTP.
+fn parse_graph_calendar(raw: &serde_json::Value) -> Option<ProviderCalendar> {
+    let provider_calendar_id = raw.get("id").and_then(|v| v.as_str())?.to_string();
+    let is_primary = raw.get("isDefaultCalendar").and_then(|v| v.as_bool()).unwrap_or(false);
+    let can_edit = raw.get("canEdit").and_then(|v| v.as_bool()).unwrap_or(false);
+    Some(ProviderCalendar {
+        provider_calendar_id,
+        name: raw.get("name").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        color: raw
+            .get("hexColor")
+            .and_then(|v| v.as_str())
+            .filter(|c| c.starts_with('#'))
+            .unwrap_or_default()
+            .to_string(),
+        is_primary,
+        access_role: if is_primary {
+            "owner".to_string()
+        } else if can_edit {
+            "writer".to_string()
+        } else {
+            "reader".to_string()
+        },
+        // Graph has no "shown in my UI" flag, so every calendar starts visible.
+        selected: true,
+    })
+}
+
 fn epoch_to_rfc3339(epoch_seconds: i64) -> Result<String> {
     chrono::DateTime::from_timestamp(epoch_seconds, 0)
         .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
@@ -569,6 +659,75 @@ fn parse_graph_time(time: &serde_json::Value) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_graph_calendar ───────────────────────────────────────────────
+
+    #[test]
+    fn parses_the_default_calendar_as_primary_and_owned() {
+        let raw = serde_json::json!({
+            "id": "AAMkAGI2primary=",
+            "name": "Calendar",
+            "hexColor": "",
+            "color": "auto",
+            "isDefaultCalendar": true,
+            "canEdit": true,
+        });
+
+        let calendar = parse_graph_calendar(&raw).expect("parse");
+
+        assert!(calendar.is_primary);
+        assert_eq!(calendar.access_role, "owner");
+        assert!(calendar.selected, "Graph has no per-calendar visibility flag");
+    }
+
+    #[test]
+    fn a_shared_read_only_calendar_parses_as_reader() {
+        let raw = serde_json::json!({
+            "id": "AAMkAGI2shared=",
+            "name": "Team calendar",
+            "isDefaultCalendar": false,
+            "canEdit": false,
+        });
+
+        let calendar = parse_graph_calendar(&raw).expect("parse");
+
+        assert_eq!(calendar.access_role, "reader");
+        assert!(!calendar.is_primary);
+        assert_eq!(calendar.name, "Team calendar");
+    }
+
+    #[test]
+    fn a_shared_editable_calendar_parses_as_writer() {
+        let raw = serde_json::json!({
+            "id": "AAMkAGI2writable=",
+            "name": "Project",
+            "isDefaultCalendar": false,
+            "canEdit": true,
+        });
+
+        assert_eq!(parse_graph_calendar(&raw).expect("parse").access_role, "writer");
+    }
+
+    #[test]
+    fn a_custom_hex_colour_is_carried_through() {
+        let raw = serde_json::json!({ "id": "AAMkAGI2=", "name": "Red one", "hexColor": "#a4373a" });
+
+        assert_eq!(parse_graph_calendar(&raw).expect("parse").color, "#a4373a");
+    }
+
+    #[test]
+    fn a_named_preset_colour_leaves_the_colour_for_the_app_to_pick() {
+        // Graph's `color` presets have no documented hex; guessing one would
+        // not match Outlook, so the UI assigns a palette slot instead.
+        let raw = serde_json::json!({ "id": "AAMkAGI2=", "name": "Preset", "hexColor": "", "color": "lightGreen" });
+
+        assert_eq!(parse_graph_calendar(&raw).expect("parse").color, "");
+    }
+
+    #[test]
+    fn an_entry_without_an_id_is_skipped() {
+        assert!(parse_graph_calendar(&serde_json::json!({ "name": "Nameless" })).is_none());
+    }
 
     #[test]
     fn parses_teams_event_with_online_meeting() {

--- a/src/components/Calendar/CalendarView.tsx
+++ b/src/components/Calendar/CalendarView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Select } from '@/components/shared/Select';
 import * as api from '@/lib/api';
+import { calendarColorMap, FALLBACK_CALENDAR_COLORS, hiddenCalendarIds, visibleEvents } from '@/lib/calendarColor';
 import { eventsAfterDelete } from '@/lib/calendarEvent';
 import { addDays, monthGrid, resolveCalendarAccountId, startOfDay, weekDays } from '@/lib/calendarGrid';
 import { errorText, isAuthError } from '@/lib/errors';
@@ -11,7 +12,7 @@ import {
   useCalendarIntegrationStore,
 } from '@/stores/calendarIntegrationStore';
 import { useLogStore } from '@/stores/logStore';
-import type { Account, CalendarEvent } from '@/types';
+import type { Account, Calendar, CalendarEvent } from '@/types';
 import { EventDetailDialog } from './EventDetailDialog';
 import { MonthGrid } from './MonthGrid';
 import { NewEventDialog } from './NewEventDialog';
@@ -118,6 +119,7 @@ export function CalendarView({ accounts, defaultAccountId }: CalendarViewProps) 
   const [viewMode, setViewMode] = useState<CalendarViewMode>('week');
   const [anchor, setAnchor] = useState<Date>(() => startOfDay(new Date()));
   const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -171,6 +173,58 @@ export function CalendarView({ accounts, defaultAccountId }: CalendarViewProps) 
     void loadEvents(selectedAccountId, rangeStart, rangeEnd);
   }, [selectedAccountId, rangeStart, rangeEnd, loadEvents]);
 
+  // The account's calendar registry: colours for the grids and the legend's
+  // show/hide toggles. Reloaded after each sync, which is what refreshes
+  // colours and picks up newly shared calendars.
+  const loadCalendars = useCallback(
+    async (accountId: string) => {
+      try {
+        setCalendars(await api.getCalendars(accountId));
+      } catch (e) {
+        // Non-fatal: without the registry every event falls back to a palette
+        // colour and nothing is hidden, so the calendar still renders.
+        addLog('error', 'sync', `Failed to load calendars: ${errorText(e)}`);
+      }
+    },
+    [addLog],
+  );
+
+  useEffect(() => {
+    if (!selectedAccountId) {
+      setCalendars([]);
+      return;
+    }
+    void loadCalendars(selectedAccountId);
+  }, [selectedAccountId, loadCalendars]);
+
+  const colorMap = useMemo(() => calendarColorMap(calendars), [calendars]);
+  const colorFor = useCallback(
+    (calendarId: string) => colorMap.get(calendarId) ?? FALLBACK_CALENDAR_COLORS[0],
+    [colorMap],
+  );
+  const hidden = useMemo(() => hiddenCalendarIds(calendars), [calendars]);
+  const shownEvents = useMemo(() => visibleEvents(events, hidden), [events, hidden]);
+
+  // Optimistic toggle: flip locally first so the grid re-filters instantly,
+  // then persist. On failure we reload the registry so the UI never keeps a
+  // toggle the DB rejected.
+  const toggleCalendar = useCallback(
+    async (calendar: Calendar) => {
+      if (!selectedAccountId) return;
+      const next = !calendar.isVisible;
+      setCalendars((current) =>
+        current.map((c) => (c.providerCalendarId === calendar.providerCalendarId ? { ...c, isVisible: next } : c)),
+      );
+      try {
+        await api.setCalendarVisible(selectedAccountId, calendar.providerCalendarId, next);
+      } catch (e) {
+        addLog('error', 'sync', `Failed to update calendar visibility: ${errorText(e)}`);
+        void loadCalendars(selectedAccountId);
+      }
+    },
+    [selectedAccountId, addLog, loadCalendars],
+  );
+
   // Keep the latest range in a ref so a finishing sync reloads what's visible now.
   const rangeRef = useRef({ rangeStart, rangeEnd });
   rangeRef.current = { rangeStart, rangeEnd };
@@ -192,6 +246,7 @@ export function CalendarView({ accounts, defaultAccountId }: CalendarViewProps) 
         if (syncIdRef.current !== syncId) return;
         const { rangeStart: start, rangeEnd: end } = rangeRef.current;
         await loadEvents(accountId, start, end);
+        await loadCalendars(accountId);
       } catch (e) {
         const msg = errorText(e);
         addLog('error', 'sync', `Calendar sync failed: ${msg}`);
@@ -207,7 +262,7 @@ export function CalendarView({ accounts, defaultAccountId }: CalendarViewProps) 
         if (syncIdRef.current === syncId) setIsSyncing(false);
       }
     },
-    [addLog, loadEvents],
+    [addLog, loadEvents, loadCalendars],
   );
 
   // Inline re-auth from the banner: run the OAuth flow for the selected
@@ -468,17 +523,58 @@ export function CalendarView({ accounts, defaultAccountId }: CalendarViewProps) 
         </div>
       </div>
 
+      {/* Calendar legend: which calendar each colour means, and a click to
+          show/hide it. Only shown when the account has more than one calendar
+          — a single-calendar account gains nothing from a one-item legend. */}
+      {calendars.length > 1 && (
+        <div className="flex items-center gap-1.5 px-4 py-1.5 border-b border-gray-200 flex-shrink-0 flex-wrap">
+          {calendars.map((calendar) => (
+            <button
+              key={calendar.providerCalendarId}
+              onClick={() => void toggleCalendar(calendar)}
+              title={
+                calendar.isVisible
+                  ? t('calendar:calendars.hideOne', { name: calendar.name })
+                  : t('calendar:calendars.showOne', { name: calendar.name })
+              }
+              aria-pressed={calendar.isVisible}
+              className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full border text-xs transition-colors ${
+                calendar.isVisible
+                  ? 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                  : 'border-gray-200 text-gray-400 hover:bg-gray-50'
+              }`}
+            >
+              <span
+                className="w-2.5 h-2.5 rounded-full flex-shrink-0 border border-black/10"
+                style={{
+                  backgroundColor: calendar.isVisible ? colorFor(calendar.providerCalendarId) : 'transparent',
+                  borderColor: colorFor(calendar.providerCalendarId),
+                }}
+              />
+              <span className="max-w-[160px] truncate">{calendar.name || calendar.providerCalendarId}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
       {/* Grid */}
       {viewMode === 'month' ? (
         <MonthGrid
           anchor={anchor}
-          events={events}
+          events={shownEvents}
+          colorFor={colorFor}
           onSelectEvent={setSelectedEvent}
           onOpenDay={openDay}
           onCreateSlot={openCreateSlot}
         />
       ) : (
-        <TimeGrid days={days} events={events} onSelectEvent={setSelectedEvent} onCreateSlot={openCreateSlot} />
+        <TimeGrid
+          days={days}
+          events={shownEvents}
+          colorFor={colorFor}
+          onSelectEvent={setSelectedEvent}
+          onCreateSlot={openCreateSlot}
+        />
       )}
 
       {enableCalendarOverlay}

--- a/src/components/Calendar/EventDetailDialog.tsx
+++ b/src/components/Calendar/EventDetailDialog.tsx
@@ -91,6 +91,7 @@ export function EventDetailDialog({
       const scope = isRecurringInstance ? deleteScope : 'instance';
       await api.deleteCalendarEvent(
         accountId,
+        event.calendarId,
         event.providerEventId,
         notify,
         cancellationMessage(notify, provider, cancelMessage),

--- a/src/components/Calendar/MonthGrid.tsx
+++ b/src/components/Calendar/MonthGrid.tsx
@@ -1,7 +1,15 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormatters } from '@/hooks/useFormatters';
-import { eventsForDay, monthGrid, startOfDay } from '@/lib/calendarGrid';
+import { eventBlockStyle, eventChipStyle } from '@/lib/calendarColor';
+import {
+  eventsForDay,
+  isMultiDayEvent,
+  layoutEventSpans,
+  monthGrid,
+  spanLaneCount,
+  startOfDay,
+} from '@/lib/calendarGrid';
 import type { CalendarEvent } from '@/types';
 
 /** Max event chips per day cell before collapsing into "+N more". */
@@ -10,9 +18,19 @@ const MAX_CHIPS = 3;
 /** Default slot proposed when double-clicking a month cell: 09:00–10:00. */
 const DEFAULT_CREATE_HOUR = 9;
 
+/** Height of one multi-day lane (bar + gap), matching the week view's band. */
+const SPAN_LANE_PX = 18;
+
+/** Vertical room the day-number row takes, so span bars start below it. */
+const DAY_NUMBER_ROW_PX = 28;
+
+const DAYS_PER_WEEK = 7;
+
 interface MonthGridProps {
   anchor: Date;
   events: CalendarEvent[];
+  /** Resolved colour per `calendarId` — see `calendarColor`. */
+  colorFor: (calendarId: string) => string;
   onSelectEvent: (event: CalendarEvent) => void;
   /** "+N more" clicked → open that day in Day view. */
   onOpenDay: (day: Date) => void;
@@ -21,7 +39,7 @@ interface MonthGridProps {
 }
 
 /** Classic 6×7 Google Calendar-style month grid (weeks start Monday). */
-export function MonthGrid({ anchor, events, onSelectEvent, onOpenDay, onCreateSlot }: MonthGridProps) {
+export function MonthGrid({ anchor, events, colorFor, onSelectEvent, onOpenDay, onCreateSlot }: MonthGridProps) {
   const { t, i18n } = useTranslation(['calendar']);
   const { time } = useFormatters();
   const cells = useMemo(() => monthGrid(anchor), [anchor]);
@@ -29,8 +47,25 @@ export function MonthGrid({ anchor, events, onSelectEvent, onOpenDay, onCreateSl
 
   const weekdayLabels = useMemo(() => {
     const fmt = new Intl.DateTimeFormat(i18n.language || 'en', { weekday: 'short' });
-    return cells.slice(0, 7).map((c) => fmt.format(c.date));
+    return cells.slice(0, DAYS_PER_WEEK).map((c) => fmt.format(c.date));
   }, [cells, i18n.language]);
+
+  // The grid is built a week at a time: a multi-day event is drawn once as a
+  // bar across that week's days instead of repeating its chip (and its start
+  // time) in every cell it touches. An event crossing a week boundary gets one
+  // clamped bar per row, with a chevron marking the continuation.
+  const weeks = useMemo(() => {
+    const rows = [];
+    for (let i = 0; i < cells.length; i += DAYS_PER_WEEK) {
+      const weekCells = cells.slice(i, i + DAYS_PER_WEEK);
+      const spans = layoutEventSpans(
+        events,
+        weekCells.map((c) => c.date),
+      );
+      rows.push({ weekCells, spans, laneCount: spanLaneCount(spans) });
+    }
+    return rows;
+  }, [cells, events]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -44,70 +79,109 @@ export function MonthGrid({ anchor, events, onSelectEvent, onOpenDay, onCreateSl
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 grid-rows-6 flex-1 min-h-0">
-        {cells.map((cell) => {
-          const dayEvents = eventsForDay(events, cell.date);
-          const visible = dayEvents.slice(0, MAX_CHIPS);
-          const overflow = dayEvents.length - visible.length;
-          const isToday = cell.date.getTime() === todayMs;
-          return (
-            <div
-              key={cell.date.getTime()}
-              className={`border-b border-r border-gray-100 p-1 min-h-0 overflow-hidden flex flex-col ${
-                cell.inMonth ? 'bg-white' : 'bg-gray-50'
-              }`}
-              onDoubleClick={(e) => {
-                // Chips and "+N more" own their clicks — only empty cell space creates.
-                if ((e.target as HTMLElement).closest('button')) return;
-                const d = cell.date;
-                const start = new Date(d.getFullYear(), d.getMonth(), d.getDate(), DEFAULT_CREATE_HOUR);
-                const end = new Date(d.getFullYear(), d.getMonth(), d.getDate(), DEFAULT_CREATE_HOUR + 1);
-                onCreateSlot(Math.floor(start.getTime() / 1000), Math.floor(end.getTime() / 1000));
-              }}
-            >
-              <div className="flex justify-end flex-shrink-0">
-                <span
-                  className={`text-xs w-6 h-6 flex items-center justify-center rounded-full ${
-                    isToday
-                      ? 'bg-primary-600 text-white font-semibold'
-                      : cell.inMonth
-                        ? 'text-gray-700'
-                        : 'text-gray-400'
+      <div className="flex flex-col flex-1 min-h-0">
+        {weeks.map(({ weekCells, spans, laneCount }) => (
+          <div key={weekCells[0].date.getTime()} className="flex-1 min-h-0 relative flex">
+            {weekCells.map((cell) => {
+              const dayEvents = eventsForDay(events, cell.date).filter((e) => !isMultiDayEvent(e));
+              // Span bars eat into the cell's vertical room, so fewer chips fit.
+              const maxChips = Math.max(1, MAX_CHIPS - laneCount);
+              const visible = dayEvents.slice(0, maxChips);
+              const overflow = dayEvents.length - visible.length;
+              const isToday = cell.date.getTime() === todayMs;
+              return (
+                <div
+                  key={cell.date.getTime()}
+                  className={`flex-1 min-w-0 border-b border-r border-gray-100 p-1 min-h-0 overflow-hidden flex flex-col ${
+                    cell.inMonth ? 'bg-white' : 'bg-gray-50'
                   }`}
+                  onDoubleClick={(e) => {
+                    // Chips and "+N more" own their clicks — only empty cell space creates.
+                    if ((e.target as HTMLElement).closest('button')) return;
+                    const d = cell.date;
+                    const start = new Date(d.getFullYear(), d.getMonth(), d.getDate(), DEFAULT_CREATE_HOUR);
+                    const end = new Date(d.getFullYear(), d.getMonth(), d.getDate(), DEFAULT_CREATE_HOUR + 1);
+                    onCreateSlot(Math.floor(start.getTime() / 1000), Math.floor(end.getTime() / 1000));
+                  }}
                 >
-                  {cell.date.getDate()}
-                </span>
-              </div>
-              <div className="space-y-0.5 min-h-0 overflow-hidden">
-                {visible.map((event) => (
+                  <div className="flex justify-end flex-shrink-0">
+                    <span
+                      className={`text-xs w-6 h-6 flex items-center justify-center rounded-full ${
+                        isToday
+                          ? 'bg-primary-600 text-white font-semibold'
+                          : cell.inMonth
+                            ? 'text-gray-700'
+                            : 'text-gray-400'
+                      }`}
+                    >
+                      {cell.date.getDate()}
+                    </span>
+                  </div>
+                  <div className="space-y-0.5 min-h-0 overflow-hidden" style={{ marginTop: laneCount * SPAN_LANE_PX }}>
+                    {visible.map((event) => (
+                      <button
+                        key={event.id}
+                        onClick={() => onSelectEvent(event)}
+                        title={event.title}
+                        className={`w-full text-left px-1.5 py-0.5 rounded text-[11px] leading-tight truncate transition-opacity hover:opacity-80 ${
+                          event.isAllDay ? '' : 'border text-gray-900'
+                        }`}
+                        style={
+                          event.isAllDay
+                            ? eventChipStyle(colorFor(event.calendarId))
+                            : eventBlockStyle(colorFor(event.calendarId), event.status === 'tentative')
+                        }
+                      >
+                        {!event.isAllDay && <span className="font-medium mr-1">{time(event.startTime)}</span>}
+                        {event.title || '—'}
+                      </button>
+                    ))}
+                    {overflow > 0 && (
+                      <button
+                        onClick={() => onOpenDay(cell.date)}
+                        className="w-full text-left px-1.5 py-0.5 text-[11px] text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded"
+                      >
+                        {t('calendar:moreEvents', { n: overflow })}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* Multi-day bars, drawn over the week's cells. The layer ignores
+                pointer events so the cells underneath stay double-clickable;
+                each bar re-enables them for itself. */}
+            {spans.length > 0 && (
+              <div
+                className="absolute inset-x-0 pointer-events-none"
+                style={{ top: DAY_NUMBER_ROW_PX, height: laneCount * SPAN_LANE_PX }}
+              >
+                {spans.map(({ event, startIndex, endIndex, continuesBefore, continuesAfter, lane }) => (
                   <button
                     key={event.id}
                     onClick={() => onSelectEvent(event)}
                     title={event.title}
-                    className={`w-full text-left px-1.5 py-0.5 rounded text-[11px] leading-tight truncate transition-colors ${
-                      event.isAllDay
-                        ? 'bg-primary-600 text-white hover:bg-primary-700'
-                        : event.status === 'tentative'
-                          ? 'bg-primary-50 text-primary-700 border border-dashed border-primary-300 hover:bg-primary-100'
-                          : 'bg-primary-100 text-primary-800 hover:bg-primary-200'
-                    }`}
+                    className={`absolute pointer-events-auto text-left px-1.5 py-0.5 text-[11px] leading-tight truncate transition-opacity hover:opacity-80 flex items-center gap-1 ${
+                      continuesBefore ? '' : 'rounded-l'
+                    } ${continuesAfter ? '' : 'rounded-r'}`}
+                    style={{
+                      top: lane * SPAN_LANE_PX,
+                      left: `calc(${(startIndex / DAYS_PER_WEEK) * 100}% + 3px)`,
+                      width: `calc(${((endIndex - startIndex + 1) / DAYS_PER_WEEK) * 100}% - 6px)`,
+                      height: SPAN_LANE_PX - 2,
+                      ...eventChipStyle(colorFor(event.calendarId)),
+                    }}
                   >
-                    {!event.isAllDay && <span className="font-medium mr-1">{time(event.startTime)}</span>}
-                    {event.title || '—'}
+                    {continuesBefore && <span aria-hidden="true">‹</span>}
+                    <span className="truncate flex-1">{event.title || '—'}</span>
+                    {continuesAfter && <span aria-hidden="true">›</span>}
                   </button>
                 ))}
-                {overflow > 0 && (
-                  <button
-                    onClick={() => onOpenDay(cell.date)}
-                    className="w-full text-left px-1.5 py-0.5 text-[11px] text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded"
-                  >
-                    {t('calendar:moreEvents', { n: overflow })}
-                  </button>
-                )}
               </div>
-            </div>
-          );
-        })}
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/Calendar/TimeGrid.scroll.test.tsx
+++ b/src/components/Calendar/TimeGrid.scroll.test.tsx
@@ -54,7 +54,15 @@ describe('TimeGrid initial scroll', () => {
 
   function mount() {
     act(() => {
-      root.render(<TimeGrid days={[day]} events={[]} onSelectEvent={() => {}} onCreateSlot={() => {}} />);
+      root.render(
+        <TimeGrid
+          days={[day]}
+          events={[]}
+          colorFor={() => '#039be5'}
+          onSelectEvent={() => {}}
+          onCreateSlot={() => {}}
+        />,
+      );
     });
   }
 

--- a/src/components/Calendar/TimeGrid.tsx
+++ b/src/components/Calendar/TimeGrid.tsx
@@ -1,14 +1,18 @@
 import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormatters } from '@/hooks/useFormatters';
+import { eventBlockStyle, eventChipStyle } from '@/lib/calendarColor';
 import {
   addDays,
   EVENT_MIN_BLOCK_PX,
   eventColumnGeometry,
   eventsForDay,
   eventTextMode,
+  isMultiDayEvent,
   layoutDayEvents,
+  layoutEventSpans,
   slotFromOffsetY,
+  spanLaneCount,
   startOfDay,
 } from '@/lib/calendarGrid';
 import type { CalendarEvent } from '@/types';
@@ -18,11 +22,16 @@ const HOUR_PX = 48;
 const MINUTES_PER_DAY = 24 * 60;
 /** On mount / view switch the grid scrolls so this hour sits at the top. */
 const INITIAL_SCROLL_HOUR = 7;
+/** Height of one lane in the multi-day spanning band (bar + gap). */
+const SPAN_LANE_PX = 20;
 
 interface TimeGridProps {
   /** The local days to render as columns (7 for week view, 1 for day view). */
   days: Date[];
   events: CalendarEvent[];
+  /** Resolved colour per `calendarId`, so each calendar's events are tinted
+   *  with the colour the provider shows them in. */
+  colorFor: (calendarId: string) => string;
   onSelectEvent: (event: CalendarEvent) => void;
   /** Double-click on an empty slot → propose a new event `[start, end)` (unix seconds). */
   onCreateSlot: (start: number, end: number) => void;
@@ -33,7 +42,7 @@ interface TimeGridProps {
  * absolutely-positioned event blocks. Overlapping events share the column
  * width via `layoutDayEvents`.
  */
-export function TimeGrid({ days, events, onSelectEvent, onCreateSlot }: TimeGridProps) {
+export function TimeGrid({ days, events, colorFor, onSelectEvent, onCreateSlot }: TimeGridProps) {
   const { t, i18n } = useTranslation(['calendar']);
   const { time } = useFormatters();
   const todayMs = startOfDay(new Date()).getTime();
@@ -74,10 +83,16 @@ export function TimeGrid({ days, events, onSelectEvent, onCreateSlot }: TimeGrid
     [i18n.language],
   );
 
+  // Multi-day events are drawn once as a bar across the days they cover, not
+  // repeated as a full-height block in every column — so they are pulled out of
+  // the per-day lists entirely.
+  const spans = useMemo(() => layoutEventSpans(events, days), [events, days]);
+  const laneCount = spanLaneCount(spans);
+
   const perDay = useMemo(
     () =>
       days.map((day) => {
-        const dayEvents = eventsForDay(events, day);
+        const dayEvents = eventsForDay(events, day).filter((e) => !isMultiDayEvent(e));
         return {
           day,
           allDay: dayEvents.filter((e) => e.isAllDay),
@@ -87,34 +102,97 @@ export function TimeGrid({ days, events, onSelectEvent, onCreateSlot }: TimeGrid
     [days, events],
   );
 
+  // "Aug 5, 9:00 AM – Aug 7, 6:00 PM" for the bar's tooltip. All-day events
+  // carry an exclusive midnight end, so step back a second to name the last
+  // day the user actually sees the event on.
+  const spanRangeFmt = useMemo(
+    () =>
+      new Intl.DateTimeFormat(i18n.language || 'en', {
+        month: 'short',
+        day: 'numeric',
+      }),
+    [i18n.language],
+  );
+  const spanTooltip = (event: (typeof events)[number]) => {
+    const lastMoment = event.isAllDay ? event.endTime - 1 : event.endTime;
+    const range = `${spanRangeFmt.format(event.startTime * 1000)} – ${spanRangeFmt.format(lastMoment * 1000)}`;
+    return event.isAllDay
+      ? `${event.title} · ${range}`
+      : `${event.title} · ${range} · ${time(event.startTime)} – ${time(event.endTime)}`;
+  };
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      {/* Day headers + all-day row */}
-      <div className="flex border-b border-gray-200 flex-shrink-0">
-        <div className="w-14 flex-shrink-0 border-r border-gray-100" />
-        {perDay.map(({ day, allDay }) => (
-          <div key={day.getTime()} className="flex-1 min-w-0 border-r border-gray-100 px-1 py-1">
-            <div
-              className={`text-xs text-center font-semibold mb-1 ${
-                day.getTime() === todayMs ? 'text-primary-600' : 'text-gray-600'
-              }`}
-            >
-              {dayLabelFmt.format(day)}
+      {/* Day headers, multi-day band, all-day row */}
+      <div className="border-b border-gray-200 flex-shrink-0">
+        {/* Day labels */}
+        <div className="flex">
+          <div className="w-14 flex-shrink-0 border-r border-gray-100" />
+          {perDay.map(({ day }) => (
+            <div key={day.getTime()} className="flex-1 min-w-0 border-r border-gray-100 px-1 py-1">
+              <div
+                className={`text-xs text-center font-semibold ${
+                  day.getTime() === todayMs ? 'text-primary-600' : 'text-gray-600'
+                }`}
+              >
+                {dayLabelFmt.format(day)}
+              </div>
             </div>
-            <div className="space-y-0.5">
-              {allDay.map((event) => (
+          ))}
+        </div>
+
+        {/* Multi-day events: one continuous bar per event, spanning the days it
+            covers, with a chevron where it runs past the visible range. */}
+        {spans.length > 0 && (
+          <div className="flex">
+            <div className="w-14 flex-shrink-0 border-r border-gray-100" />
+            <div className="flex-1 min-w-0 relative" style={{ height: laneCount * SPAN_LANE_PX }}>
+              {spans.map(({ event, startIndex, endIndex, continuesBefore, continuesAfter, lane }) => (
                 <button
                   key={event.id}
                   onClick={() => onSelectEvent(event)}
-                  title={`${event.title} · ${t('calendar:allDay')}`}
-                  className="w-full text-left px-1.5 py-0.5 rounded text-[11px] leading-tight truncate bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+                  title={spanTooltip(event)}
+                  className={`absolute text-left px-1.5 py-0.5 text-[11px] leading-tight truncate transition-opacity hover:opacity-80 flex items-center gap-1 ${
+                    continuesBefore ? '' : 'rounded-l'
+                  } ${continuesAfter ? '' : 'rounded-r'}`}
+                  style={{
+                    top: lane * SPAN_LANE_PX,
+                    left: `calc(${(startIndex / days.length) * 100}% + 2px)`,
+                    width: `calc(${((endIndex - startIndex + 1) / days.length) * 100}% - 4px)`,
+                    height: SPAN_LANE_PX - 2,
+                    ...eventChipStyle(colorFor(event.calendarId)),
+                  }}
                 >
-                  {event.title || '—'}
+                  {continuesBefore && <span aria-hidden="true">‹</span>}
+                  <span className="truncate flex-1">{event.title || '—'}</span>
+                  {continuesAfter && <span aria-hidden="true">›</span>}
                 </button>
               ))}
             </div>
           </div>
-        ))}
+        )}
+
+        {/* Single-day all-day events, per column */}
+        <div className="flex">
+          <div className="w-14 flex-shrink-0 border-r border-gray-100" />
+          {perDay.map(({ day, allDay }) => (
+            <div key={day.getTime()} className="flex-1 min-w-0 border-r border-gray-100 px-1 pb-1">
+              <div className="space-y-0.5">
+                {allDay.map((event) => (
+                  <button
+                    key={event.id}
+                    onClick={() => onSelectEvent(event)}
+                    title={`${event.title} · ${t('calendar:allDay')}`}
+                    className="w-full text-left px-1.5 py-0.5 rounded text-[11px] leading-tight truncate transition-opacity hover:opacity-80"
+                    style={eventChipStyle(colorFor(event.calendarId))}
+                  >
+                    {event.title || '—'}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* Scrollable time grid */}
@@ -176,16 +254,13 @@ export function TimeGrid({ days, events, onSelectEvent, onCreateSlot }: TimeGrid
                       onClick={() => onSelectEvent(event)}
                       onDoubleClick={(e) => e.stopPropagation()}
                       title={`${event.title} · ${time(event.startTime)} – ${time(event.endTime)}`}
-                      className={`absolute text-left rounded px-1.5 py-0.5 text-[11px] leading-tight overflow-hidden border transition-colors flex flex-col items-stretch justify-start ${
-                        event.status === 'tentative'
-                          ? 'bg-primary-50 border-dashed border-primary-300 text-primary-700 hover:bg-primary-100'
-                          : 'bg-primary-100 border-primary-200 text-primary-900 hover:bg-primary-200'
-                      }`}
+                      className="absolute text-left rounded px-1.5 py-0.5 text-[11px] leading-tight overflow-hidden border text-gray-900 transition-opacity hover:opacity-80 flex flex-col items-stretch justify-start"
                       style={{
                         top,
                         height,
                         left: `${leftPct}%`,
                         width: `calc(${widthPct}% - 2px)`,
+                        ...eventBlockStyle(colorFor(event.calendarId), event.status === 'tentative'),
                       }}
                     >
                       {textMode === 'two-lines' && (

--- a/src/components/Settings/CalendarSettings.tsx
+++ b/src/components/Settings/CalendarSettings.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Select } from '@/components/shared/Select';
 import * as api from '@/lib/api';
+import { calendarColor } from '@/lib/calendarColor';
 import { errorText, isAuthError } from '@/lib/errors';
 import { useAccountStore } from '@/stores/accountStore';
 import { calendarCapableAccounts, useCalendarIntegrationStore } from '@/stores/calendarIntegrationStore';
 import { useLogStore } from '@/stores/logStore';
+import type { Calendar } from '@/types';
 
 /** Lead-time choices for the upcoming-meeting notification (minutes). */
 const LEAD_TIME_OPTIONS = [1, 5, 10, 15, 30, 60] as const;
@@ -37,6 +39,10 @@ export function CalendarSettings() {
    *  Settings. */
   const [reauthAccountId, setReauthAccountId] = useState<string | null>(null);
   const [isReauthing, setIsReauthing] = useState(false);
+  /** Calendars per account id, for the per-calendar show/hide list. Loaded
+   *  only for accounts whose integration is on — a disabled account has no
+   *  registry to show. */
+  const [calendarsByAccount, setCalendarsByAccount] = useState<Record<string, Calendar[]>>({});
 
   const runEnableSync = (accountId: string) => {
     // First sync right away so the calendar fills in without waiting for the
@@ -116,6 +122,37 @@ export function CalendarSettings() {
     };
   }, []);
 
+  // Load the calendar registry for every account whose integration is on.
+  // Keyed on the id list rather than the Set itself so enabling an account
+  // fetches its calendars without refetching the others on every render.
+  const enabledAccountKey = capableAccounts
+    .filter((a) => integrationIds.has(a.id))
+    .map((a) => a.id)
+    .sort()
+    .join(',');
+  useEffect(() => {
+    if (!integrationLoaded) return;
+    let cancelled = false;
+    const ids = enabledAccountKey ? enabledAccountKey.split(',') : [];
+    void (async () => {
+      const entries = await Promise.all(
+        ids.map(async (id) => {
+          try {
+            return [id, await api.getCalendars(id)] as const;
+          } catch (e) {
+            addLog('error', 'sync', `Failed to load calendars: ${errorText(e)}`);
+            return [id, [] as Calendar[]] as const;
+          }
+        }),
+      );
+      if (cancelled) return;
+      setCalendarsByAccount(Object.fromEntries(entries));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabledAccountKey, integrationLoaded, addLog]);
+
   const persistEnabled = (next: boolean) => {
     const previous = notificationsEnabled;
     setNotificationsEnabled(next);
@@ -125,6 +162,33 @@ export function CalendarSettings() {
       setNotificationsEnabled(previous);
       setError(errorText(e));
       addLog('error', 'system', `Failed to save calendar notification pref: ${errorText(e)}`);
+    });
+  };
+
+  const loadCalendarsFor = (accountId: string) => {
+    api
+      .getCalendars(accountId)
+      .then((list) => setCalendarsByAccount((current) => ({ ...current, [accountId]: list })))
+      .catch((e) => {
+        // Non-fatal: the account toggle above still works, only the
+        // per-calendar list is missing.
+        addLog('error', 'sync', `Failed to load calendars: ${errorText(e)}`);
+      });
+  };
+
+  const toggleCalendarVisible = (accountId: string, calendar: Calendar, next: boolean) => {
+    setError(null);
+    setCalendarsByAccount((current) => ({
+      ...current,
+      [accountId]: (current[accountId] ?? []).map((c) =>
+        c.providerCalendarId === calendar.providerCalendarId ? { ...c, isVisible: next } : c,
+      ),
+    }));
+    api.setCalendarVisible(accountId, calendar.providerCalendarId, next).catch((e) => {
+      // Revert the optimistic flip by reloading the authoritative list.
+      setError(errorText(e));
+      addLog('error', 'system', `Failed to save calendar visibility: ${errorText(e)}`);
+      loadCalendarsFor(accountId);
     });
   };
 
@@ -157,29 +221,66 @@ export function CalendarSettings() {
             <div className="rounded-lg border border-gray-700 bg-[#1f1f20] divide-y divide-gray-700">
               {capableAccounts.map((account) => {
                 const enabled = integrationIds.has(account.id);
+                const accountCalendars = calendarsByAccount[account.id] ?? [];
                 return (
-                  <div key={account.id} className="flex items-center justify-between gap-4 px-4 py-3">
-                    <div className="min-w-0">
-                      <span className="text-sm text-gray-100 block truncate">{account.email}</span>
-                      <span className="text-xs text-gray-500 capitalize">{account.provider}</span>
-                    </div>
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={enabled}
-                      aria-label={t('settings:calendar.accountToggleAria', { email: account.email })}
-                      disabled={!integrationLoaded}
-                      onClick={() => toggleAccountIntegration(account.id, !enabled)}
-                      className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${
-                        enabled ? 'bg-primary-600' : 'bg-neutral-600'
-                      }`}
-                    >
-                      <span
-                        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
-                          enabled ? 'translate-x-5' : 'translate-x-1'
+                  <div key={account.id}>
+                    <div className="flex items-center justify-between gap-4 px-4 py-3">
+                      <div className="min-w-0">
+                        <span className="text-sm text-gray-100 block truncate">{account.email}</span>
+                        <span className="text-xs text-gray-500 capitalize">{account.provider}</span>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={enabled}
+                        aria-label={t('settings:calendar.accountToggleAria', { email: account.email })}
+                        disabled={!integrationLoaded}
+                        onClick={() => toggleAccountIntegration(account.id, !enabled)}
+                        className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${
+                          enabled ? 'bg-primary-600' : 'bg-neutral-600'
                         }`}
-                      />
-                    </button>
+                      >
+                        <span
+                          className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                            enabled ? 'translate-x-5' : 'translate-x-1'
+                          }`}
+                        />
+                      </button>
+                    </div>
+                    {/* Which of the account's calendars appear in the calendar
+                        view. Hidden ones keep syncing, so re-showing one is
+                        instant. Only rendered when there is a real choice. */}
+                    {enabled && accountCalendars.length > 1 && (
+                      <div className="px-4 pb-3 -mt-1 space-y-1.5">
+                        {accountCalendars.map((calendar) => (
+                          <label
+                            key={calendar.providerCalendarId}
+                            className="flex items-center gap-2.5 cursor-pointer group"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={calendar.isVisible}
+                              onChange={(e) => toggleCalendarVisible(account.id, calendar, e.target.checked)}
+                              className="rounded border-gray-600 bg-transparent text-primary-600 focus:ring-primary-600 focus:ring-offset-0"
+                            />
+                            <span
+                              className="w-2.5 h-2.5 rounded-full flex-shrink-0 border border-black/20"
+                              style={{
+                                backgroundColor: calendarColor(calendar.color, calendar.providerCalendarId),
+                              }}
+                            />
+                            <span className="text-xs text-gray-300 truncate group-hover:text-gray-100">
+                              {calendar.name || calendar.providerCalendarId}
+                            </span>
+                            {calendar.isPrimary && (
+                              <span className="text-[10px] text-gray-500 flex-shrink-0">
+                                {t('settings:calendar.primaryCalendar')}
+                              </span>
+                            )}
+                          </label>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   Attachment,
   AttachmentRule,
   BackfillStatus,
+  Calendar,
   CalendarEvent,
   CalendarInvite,
   CatalogModel,
@@ -1370,6 +1371,18 @@ export async function getCalendarEvents(
   return invoke('get_calendar_events', { accountId, rangeStart, rangeEnd });
 }
 
+/** Every calendar the account can see (its own, shared with it, subscribed),
+ *  primary first. Drives per-calendar colours and the show/hide filter. */
+export async function getCalendars(accountId: string): Promise<Calendar[]> {
+  return invoke('get_calendars', { accountId });
+}
+
+/** Show or hide one calendar in the calendar view. Hidden calendars keep
+ *  syncing in the background, so toggling one back on is instant. */
+export async function setCalendarVisible(accountId: string, calendarId: string, visible: boolean): Promise<void> {
+  return invoke('set_calendar_visible', { accountId, calendarId, visible });
+}
+
 /** Create a calendar event on the provider (double-click "New event" flow).
  *  Times are unix seconds; the backend validates (non-empty title, end >
  *  start, attendee shape — max 100) and returns the stored event — for Gmail
@@ -1408,12 +1421,20 @@ export async function createCalendarEvent(
  *  occurrence. */
 export async function deleteCalendarEvent(
   accountId: string,
+  calendarId: string,
   providerEventId: string,
   notifyAttendees: boolean,
   message: string,
   scope: CalendarDeleteScope = 'instance',
 ): Promise<void> {
-  return invoke('delete_calendar_event', { accountId, providerEventId, notifyAttendees, message, scope });
+  return invoke('delete_calendar_event', {
+    accountId,
+    calendarId,
+    providerEventId,
+    notifyAttendees,
+    message,
+    scope,
+  });
 }
 
 /** The calendar invite (.ics) carried by an email, or null when the email

--- a/src/lib/calendarColor.test.ts
+++ b/src/lib/calendarColor.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CalendarColorSource,
+  calendarColor,
+  calendarColorMap,
+  eventBlockStyle,
+  eventChipStyle,
+  FALLBACK_CALENDAR_COLORS,
+  hiddenCalendarIds,
+  isHexColor,
+  readableTextColor,
+  visibleEvents,
+  withAlpha,
+} from './calendarColor';
+
+function cal(providerCalendarId: string, color: string, isVisible = true): CalendarColorSource {
+  return { providerCalendarId, color, isVisible };
+}
+
+describe('isHexColor', () => {
+  it('accepts 6-digit and 3-digit hex', () => {
+    expect(isHexColor('#33b679')).toBe(true);
+    expect(isHexColor('#abc')).toBe(true);
+  });
+
+  it('rejects the empty colour providers send when they have none', () => {
+    expect(isHexColor('')).toBe(false);
+  });
+
+  it('rejects named colours and malformed values', () => {
+    expect(isHexColor('lightGreen')).toBe(false);
+    expect(isHexColor('#12345')).toBe(false);
+    expect(isHexColor('33b679')).toBe(false);
+    expect(isHexColor(null)).toBe(false);
+    expect(isHexColor(undefined)).toBe(false);
+  });
+});
+
+describe('calendarColor', () => {
+  it("uses the provider's own colour when there is one", () => {
+    expect(calendarColor('#33b679', 'team@group.calendar.google.com')).toBe('#33b679');
+  });
+
+  it('expands shorthand hex so downstream maths has one shape to handle', () => {
+    expect(calendarColor('#abc', 'cal')).toBe('#aabbcc');
+  });
+
+  it('falls back to a palette slot when the provider gave no colour', () => {
+    const color = calendarColor('', 'team@group.calendar.google.com');
+    expect(FALLBACK_CALENDAR_COLORS).toContain(color);
+  });
+
+  it('gives the same calendar the same fallback colour every time', () => {
+    // Colours must not shuffle between launches — the user learns them.
+    const first = calendarColor('', 'holidays@group.v.calendar.google.com');
+    const second = calendarColor(null, 'holidays@group.v.calendar.google.com');
+    expect(second).toBe(first);
+  });
+
+  it('gives different calendars different fallback colours', () => {
+    const ids = ['a@group.calendar.google.com', 'b@group.calendar.google.com', 'c@group.calendar.google.com'];
+    const colors = new Set(ids.map((id) => calendarColor('', id)));
+    expect(colors.size).toBe(ids.length);
+  });
+});
+
+describe('readableTextColor', () => {
+  it('puts dark text on light fills', () => {
+    expect(readableTextColor('#f6bf26')).toBe('#111827');
+  });
+
+  it('puts white text on dark fills', () => {
+    expect(readableTextColor('#0b8043')).toBe('#ffffff');
+  });
+
+  it('keeps every fallback palette colour legible', () => {
+    for (const color of FALLBACK_CALENDAR_COLORS) {
+      expect(['#111827', '#ffffff']).toContain(readableTextColor(color));
+    }
+  });
+});
+
+describe('withAlpha', () => {
+  it('appends the alpha byte', () => {
+    expect(withAlpha('#039be5', 1)).toBe('#039be5ff');
+    expect(withAlpha('#039be5', 0)).toBe('#039be500');
+  });
+
+  it('clamps out-of-range alpha instead of emitting invalid hex', () => {
+    expect(withAlpha('#039be5', 5)).toBe('#039be5ff');
+    expect(withAlpha('#039be5', -1)).toBe('#039be500');
+  });
+
+  it('always produces a two-digit alpha byte', () => {
+    expect(withAlpha('#039be5', 0.02)).toMatch(/^#[0-9a-f]{8}$/);
+  });
+});
+
+describe('eventBlockStyle', () => {
+  it('tints the block in the calendar colour with a solid left rule', () => {
+    const style = eventBlockStyle('#33b679', false);
+    expect(style.borderColor).toBe('#33b679');
+    expect(style.backgroundColor.startsWith('#33b679')).toBe(true);
+    expect(style.borderStyle).toBe('solid');
+  });
+
+  it('marks tentative events with a dashed border and a fainter tint', () => {
+    const tentative = eventBlockStyle('#33b679', true);
+    const confirmed = eventBlockStyle('#33b679', false);
+    expect(tentative.borderStyle).toBe('dashed');
+    expect(tentative.backgroundColor).not.toBe(confirmed.backgroundColor);
+  });
+});
+
+describe('eventChipStyle', () => {
+  it('fills with the calendar colour and picks contrasting text', () => {
+    expect(eventChipStyle('#0b8043')).toEqual({ backgroundColor: '#0b8043', color: '#ffffff' });
+    expect(eventChipStyle('#f6bf26')).toEqual({ backgroundColor: '#f6bf26', color: '#111827' });
+  });
+});
+
+describe('calendarColorMap', () => {
+  it('maps each calendar id to its resolved colour', () => {
+    const map = calendarColorMap([cal('primary', '#039be5'), cal('team@g.com', '#33b679')]);
+    expect(map.get('primary')).toBe('#039be5');
+    expect(map.get('team@g.com')).toBe('#33b679');
+  });
+
+  it('resolves a fallback for calendars the provider gave no colour', () => {
+    const map = calendarColorMap([cal('team@g.com', '')]);
+    expect(FALLBACK_CALENDAR_COLORS).toContain(map.get('team@g.com'));
+  });
+
+  it('includes hidden calendars, so re-showing one needs no refetch', () => {
+    const map = calendarColorMap([cal('team@g.com', '#33b679', false)]);
+    expect(map.get('team@g.com')).toBe('#33b679');
+  });
+});
+
+describe('hiddenCalendarIds', () => {
+  it('collects only the calendars switched off', () => {
+    const hidden = hiddenCalendarIds([
+      cal('primary', '#039be5'),
+      cal('holidays@g.com', '#0b8043', false),
+      cal('team@g.com', '#33b679', false),
+    ]);
+    expect(hidden).toEqual(new Set(['holidays@g.com', 'team@g.com']));
+  });
+
+  it('is empty when everything is visible', () => {
+    expect(hiddenCalendarIds([cal('primary', '#039be5')]).size).toBe(0);
+  });
+});
+
+describe('visibleEvents', () => {
+  const events = [
+    { id: 'a', calendarId: 'primary' },
+    { id: 'b', calendarId: 'team@g.com' },
+    { id: 'c', calendarId: 'primary' },
+  ];
+
+  it('drops events belonging to hidden calendars', () => {
+    const shown = visibleEvents(events, new Set(['team@g.com']));
+    expect(shown.map((e) => e.id)).toEqual(['a', 'c']);
+  });
+
+  it('keeps everything when nothing is hidden', () => {
+    expect(visibleEvents(events, new Set())).toHaveLength(3);
+  });
+
+  it('can hide every event', () => {
+    expect(visibleEvents(events, new Set(['primary', 'team@g.com']))).toEqual([]);
+  });
+
+  it('keeps the same meeting shown via a visible calendar when its copy in a hidden one is dropped', () => {
+    // Providers repeat one event id across every calendar it appears in, so
+    // hiding one calendar must not hide the copy in another.
+    const duplicated = [
+      { id: 'acc:primary:ev', calendarId: 'primary' },
+      { id: 'acc:team@g.com:ev', calendarId: 'team@g.com' },
+    ];
+    const shown = visibleEvents(duplicated, new Set(['team@g.com']));
+    expect(shown).toHaveLength(1);
+    expect(shown[0].calendarId).toBe('primary');
+  });
+});

--- a/src/lib/calendarColor.ts
+++ b/src/lib/calendarColor.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-calendar colours for the calendar view.
+ *
+ * Events are tinted by the calendar they belong to, using the colour the
+ * provider reports (Google `calendarList.backgroundColor`, Graph `hexColor`).
+ * Providers do not always give one — Graph's named presets have no documented
+ * hex — so calendars without a colour get a deterministic slot from a fallback
+ * palette instead: same calendar, same colour, every launch.
+ *
+ * All functions here are pure so they can be unit-tested without React.
+ */
+
+/** Fallback palette for calendars the provider gave no colour for. Chosen to
+ *  stay distinguishable from each other and legible in light and dark mode. */
+export const FALLBACK_CALENDAR_COLORS = [
+  '#039be5', // blue
+  '#33b679', // green
+  '#f4511e', // orange
+  '#8e24aa', // purple
+  '#e67c73', // salmon
+  '#f6bf26', // yellow
+  '#0b8043', // dark green
+  '#3f51b5', // indigo
+  '#d81b60', // pink
+  '#616161', // grey
+] as const;
+
+const HEX_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/** Whether a provider colour string is a usable hex colour. */
+export function isHexColor(value: string | null | undefined): boolean {
+  return typeof value === 'string' && HEX_RE.test(value.trim());
+}
+
+/** Expand `#abc` to `#aabbcc`; pass `#aabbcc` through. Input must be valid. */
+function expand(hex: string): string {
+  const raw = hex.trim().toLowerCase();
+  if (raw.length === 4) {
+    return `#${raw[1]}${raw[1]}${raw[2]}${raw[2]}${raw[3]}${raw[3]}`;
+  }
+  return raw;
+}
+
+/** Stable non-negative hash of a string — FNV-1a, so the same calendar id
+ *  always lands on the same palette slot across launches and machines. */
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * The colour to paint a calendar with: the provider's own colour when it gave
+ * one, otherwise a deterministic fallback keyed on the calendar's id.
+ */
+export function calendarColor(providerColor: string | null | undefined, calendarId: string): string {
+  if (isHexColor(providerColor)) {
+    return expand(providerColor as string);
+  }
+  return FALLBACK_CALENDAR_COLORS[hashString(calendarId) % FALLBACK_CALENDAR_COLORS.length];
+}
+
+/** Relative luminance per WCAG 2.1, for a valid `#rrggbb` colour. */
+function luminance(hex: string): number {
+  const full = expand(hex);
+  const channels = [full.slice(1, 3), full.slice(3, 5), full.slice(5, 7)].map((pair) => {
+    const srgb = parseInt(pair, 16) / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+/**
+ * Black or white text for a solid fill of `hex`, whichever contrasts more.
+ * Used by the filled chips (all-day bars, month chips, legend swatches) where
+ * the calendar colour is the background.
+ */
+export function readableTextColor(hex: string): string {
+  // 0.179 is the luminance at which white and black text contrast equally
+  // against the fill; above it, black wins.
+  return luminance(hex) > 0.179 ? '#111827' : '#ffffff';
+}
+
+/** An 8-digit hex with `alpha` (0–1) applied, for translucent fills. */
+export function withAlpha(hex: string, alpha: number): string {
+  const clamped = Math.min(1, Math.max(0, alpha));
+  const byte = Math.round(clamped * 255)
+    .toString(16)
+    .padStart(2, '0');
+  return `${expand(hex)}${byte}`;
+}
+
+/** Inline styles for one event block, given its calendar colour.
+ *
+ *  Timed blocks use a translucent tint plus a solid left rule rather than a
+ *  solid fill: a full-strength fill of ten different calendar colours makes a
+ *  busy week unreadable, and a tint keeps the app's own text colour legible in
+ *  both light and dark mode without per-colour contrast maths. Tentative
+ *  events keep the existing dashed treatment, just in the calendar's colour. */
+export function eventBlockStyle(color: string, tentative: boolean): Record<string, string> {
+  return {
+    backgroundColor: withAlpha(color, tentative ? 0.1 : 0.22),
+    borderColor: color,
+    borderLeftWidth: '3px',
+    borderStyle: tentative ? 'dashed' : 'solid',
+  };
+}
+
+/** Inline styles for a solid-filled chip (all-day bars, month-view chips). */
+export function eventChipStyle(color: string): Record<string, string> {
+  return { backgroundColor: color, color: readableTextColor(color) };
+}
+
+/** Minimal shape `calendarColorMap` / `hiddenCalendarIds` need — keeps these
+ *  helpers testable without building a whole `Calendar`. */
+export interface CalendarColorSource {
+  providerCalendarId: string;
+  color: string;
+  isVisible: boolean;
+}
+
+/** Resolved colour per calendar id, for the grids' `colorFor` lookup. */
+export function calendarColorMap(calendars: readonly CalendarColorSource[]): Map<string, string> {
+  return new Map(calendars.map((c) => [c.providerCalendarId, calendarColor(c.color, c.providerCalendarId)]));
+}
+
+/** Ids of the calendars the user switched off in Settings → Calendar. */
+export function hiddenCalendarIds(calendars: readonly CalendarColorSource[]): Set<string> {
+  return new Set(calendars.filter((c) => !c.isVisible).map((c) => c.providerCalendarId));
+}
+
+/**
+ * Drop events belonging to hidden calendars.
+ *
+ * Hidden calendars keep syncing, so this render-time filter is what actually
+ * hides them — and it makes re-showing a calendar instant instead of waiting
+ * for the next sync.
+ */
+export function visibleEvents<T extends { calendarId: string }>(
+  events: readonly T[],
+  hidden: ReadonlySet<string>,
+): T[] {
+  if (hidden.size === 0) return events as T[];
+  return events.filter((e) => !hidden.has(e.calendarId));
+}

--- a/src/lib/calendarGrid.test.ts
+++ b/src/lib/calendarGrid.test.ts
@@ -9,10 +9,13 @@ import {
   eventColumnGeometry,
   eventsForDay,
   eventTextMode,
+  isMultiDayEvent,
   layoutDayEvents,
+  layoutEventSpans,
   monthGrid,
   resolveCalendarAccountId,
   slotFromOffsetY,
+  spanLaneCount,
   startOfDay,
   startOfWeekMonday,
   startsIn,
@@ -429,5 +432,165 @@ describe('resolveCalendarAccountId', () => {
 
   it('returns null when no account is enabled', () => {
     expect(resolveCalendarAccountId([{ id: 'x', enabled: false }], 'x', 'x')).toBeNull();
+  });
+});
+
+// ── Multi-day events ─────────────────────────────────────────────────────────
+
+describe('isMultiDayEvent', () => {
+  it('treats a normal timed meeting as single-day', () => {
+    const e = makeEvent({ startTime: sec(2026, 8, 7, 10, 0), endTime: sec(2026, 8, 7, 11, 0) });
+    expect(isMultiDayEvent(e)).toBe(false);
+  });
+
+  it('treats a late-night meeting crossing midnight as single-day', () => {
+    // 11:00 PM – 12:30 AM is a 90-minute meeting, not a multi-day event — it
+    // belongs in the time grid as two blocks, not in the spanning band.
+    const e = makeEvent({ startTime: sec(2026, 8, 7, 23, 0), endTime: sec(2026, 8, 8, 0, 30) });
+    expect(isMultiDayEvent(e)).toBe(false);
+  });
+
+  it('treats a one-day all-day event as single-day', () => {
+    const e = makeEvent({
+      isAllDay: true,
+      startTime: sec(2026, 8, 7),
+      endTime: sec(2026, 8, 8), // exclusive end — exactly 24h
+    });
+    expect(isMultiDayEvent(e)).toBe(false);
+  });
+
+  it('treats a multi-day all-day event as multi-day', () => {
+    const e = makeEvent({ isAllDay: true, startTime: sec(2026, 8, 7), endTime: sec(2026, 8, 10) });
+    expect(isMultiDayEvent(e)).toBe(true);
+  });
+
+  it('treats a timed event longer than a day as multi-day', () => {
+    const e = makeEvent({ startTime: sec(2026, 8, 7, 23, 0), endTime: sec(2026, 8, 10, 0, 30) });
+    expect(isMultiDayEvent(e)).toBe(true);
+  });
+});
+
+describe('layoutEventSpans', () => {
+  const week = weekDays(day(2026, 8, 3)); // Mon 3 Aug – Sun 9 Aug
+
+  it('turns a multi-day event into one span across the days it covers', () => {
+    const vacation = makeEvent({
+      id: 'offsite',
+      title: 'Team offsite',
+      startTime: sec(2026, 8, 5, 9, 0),
+      endTime: sec(2026, 8, 7, 18, 0),
+    });
+
+    const spans = layoutEventSpans([vacation], week);
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].startIndex).toBe(2); // Wed 5
+    expect(spans[0].endIndex).toBe(4); // Fri 7
+    expect(spans[0].continuesBefore).toBe(false);
+    expect(spans[0].continuesAfter).toBe(false);
+  });
+
+  it('ignores single-day events — they stay in the grid', () => {
+    const meeting = makeEvent({ startTime: sec(2026, 8, 5, 10, 0), endTime: sec(2026, 8, 5, 11, 0) });
+    expect(layoutEventSpans([meeting], week)).toEqual([]);
+  });
+
+  it('clamps a span that starts before the visible week and flags the continuation', () => {
+    const e = makeEvent({ startTime: sec(2026, 7, 30, 9, 0), endTime: sec(2026, 8, 5, 18, 0) });
+
+    const [span] = layoutEventSpans([e], week);
+
+    expect(span.startIndex).toBe(0);
+    expect(span.endIndex).toBe(2);
+    expect(span.continuesBefore).toBe(true);
+    expect(span.continuesAfter).toBe(false);
+  });
+
+  it('clamps a span that runs past the visible week and flags the continuation', () => {
+    const e = makeEvent({ startTime: sec(2026, 8, 6, 9, 0), endTime: sec(2026, 8, 20, 18, 0) });
+
+    const [span] = layoutEventSpans([e], week);
+
+    expect(span.startIndex).toBe(3);
+    expect(span.endIndex).toBe(6);
+    expect(span.continuesAfter).toBe(true);
+  });
+
+  it('flags both continuations for an event covering the whole visible week', () => {
+    const e = makeEvent({ startTime: sec(2026, 7, 1), endTime: sec(2026, 9, 1) });
+
+    const [span] = layoutEventSpans([e], week);
+
+    expect(span.startIndex).toBe(0);
+    expect(span.endIndex).toBe(6);
+    expect(span.continuesBefore).toBe(true);
+    expect(span.continuesAfter).toBe(true);
+  });
+
+  it('drops events that do not reach the visible week at all', () => {
+    const e = makeEvent({ startTime: sec(2026, 6, 1), endTime: sec(2026, 6, 5) });
+    expect(layoutEventSpans([e], week)).toEqual([]);
+  });
+
+  it('stacks overlapping spans on separate lanes', () => {
+    const a = makeEvent({ id: 'a', startTime: sec(2026, 8, 3), endTime: sec(2026, 8, 6) });
+    const b = makeEvent({ id: 'b', startTime: sec(2026, 8, 4), endTime: sec(2026, 8, 8) });
+
+    const spans = layoutEventSpans([a, b], week);
+
+    expect(spans.find((s) => s.event.id === 'a')?.lane).toBe(0);
+    expect(spans.find((s) => s.event.id === 'b')?.lane).toBe(1);
+  });
+
+  it('reuses a lane once the previous span in it has ended', () => {
+    const early = makeEvent({ id: 'early', startTime: sec(2026, 8, 3), endTime: sec(2026, 8, 5) });
+    const late = makeEvent({ id: 'late', startTime: sec(2026, 8, 6), endTime: sec(2026, 8, 8) });
+
+    const spans = layoutEventSpans([early, late], week);
+
+    expect(spans.every((s) => s.lane === 0)).toBe(true);
+  });
+
+  it('keeps a one-day gap between spans in the same lane readable', () => {
+    // Touching spans (one ends Tue, the next starts Wed) must not share a lane
+    // edge-to-edge ambiguity — the later one may reuse the lane only when a
+    // full day separates them in the grid.
+    const a = makeEvent({ id: 'a', startTime: sec(2026, 8, 3), endTime: sec(2026, 8, 5) }); // Mon–Tue
+    const b = makeEvent({ id: 'b', startTime: sec(2026, 8, 5), endTime: sec(2026, 8, 7) }); // Wed–Thu
+
+    const spans = layoutEventSpans([a, b], week);
+
+    expect(spans.find((s) => s.event.id === 'a')?.endIndex).toBe(1);
+    expect(spans.find((s) => s.event.id === 'b')?.startIndex).toBe(2);
+    expect(spans.every((s) => s.lane === 0)).toBe(true);
+  });
+
+  it('is stable in day view (a single visible day)', () => {
+    const e = makeEvent({ startTime: sec(2026, 8, 5, 9, 0), endTime: sec(2026, 8, 9, 18, 0) });
+
+    const [span] = layoutEventSpans([e], [day(2026, 8, 6)]);
+
+    expect(span.startIndex).toBe(0);
+    expect(span.endIndex).toBe(0);
+    expect(span.continuesBefore).toBe(true);
+    expect(span.continuesAfter).toBe(true);
+  });
+});
+
+describe('spanLaneCount', () => {
+  it('is zero without spans', () => {
+    expect(spanLaneCount([])).toBe(0);
+  });
+
+  it('counts the lanes needed to draw every span', () => {
+    const week = weekDays(day(2026, 8, 3));
+    const spans = layoutEventSpans(
+      [
+        makeEvent({ id: 'a', startTime: sec(2026, 8, 3), endTime: sec(2026, 8, 6) }),
+        makeEvent({ id: 'b', startTime: sec(2026, 8, 4), endTime: sec(2026, 8, 8) }),
+      ],
+      week,
+    );
+    expect(spanLaneCount(spans)).toBe(2);
   });
 });

--- a/src/lib/calendarGrid.ts
+++ b/src/lib/calendarGrid.ts
@@ -130,6 +130,103 @@ export function layoutDayEvents(events: CalendarEvent[]): PositionedEvent[] {
   return result;
 }
 
+// ── Multi-day events ─────────────────────────────────────────────────────────
+
+/** A day in seconds. An event must run *longer* than this to be multi-day. */
+const ONE_DAY_SECS = 86_400;
+
+/**
+ * Whether an event spans several days and so belongs in the spanning band
+ * above the grid rather than as a block inside the day columns.
+ *
+ * The test is duration, not "does it touch two dates": a 23:00 → 00:30 meeting
+ * touches two dates but is 90 minutes long and reads correctly as two blocks in
+ * the time grid. A one-day all-day event is exactly 24h, so the comparison is
+ * deliberately strict — only something longer than a full day spans.
+ */
+export function isMultiDayEvent(e: CalendarEvent): boolean {
+  return effectiveEnd(e) - e.startTime > ONE_DAY_SECS;
+}
+
+/** A multi-day event placed across the visible day columns. */
+export interface EventSpan {
+  event: CalendarEvent;
+  /** First covered column, clamped to the visible range. */
+  startIndex: number;
+  /** Last covered column (inclusive), clamped to the visible range. */
+  endIndex: number;
+  /** The event already started before the first visible day. */
+  continuesBefore: boolean;
+  /** The event runs past the last visible day. */
+  continuesAfter: boolean;
+  /** Stacking row, so overlapping spans never draw on top of each other. */
+  lane: number;
+}
+
+/**
+ * Place every multi-day event in `events` across the `days` columns as a single
+ * continuous bar, stacked into lanes so overlapping spans stay readable.
+ *
+ * Single-day events are skipped (they belong in the day columns), as are events
+ * that do not reach the visible range at all. Spans are clamped to the visible
+ * days, with `continuesBefore` / `continuesAfter` recording that the real event
+ * extends further.
+ */
+export function layoutEventSpans(events: CalendarEvent[], days: Date[]): EventSpan[] {
+  if (days.length === 0) return [];
+  const dayStarts = days.map((d) => Math.floor(startOfDay(d).getTime() / 1000));
+  const dayEnds = days.map((d) => Math.floor(addDays(d, 1).getTime() / 1000));
+  const rangeStart = dayStarts[0];
+  const rangeEnd = dayEnds[dayEnds.length - 1];
+
+  const candidates = events
+    .filter(isMultiDayEvent)
+    .filter((e) => e.startTime < rangeEnd && effectiveEnd(e) > rangeStart)
+    .map((event) => {
+      const end = effectiveEnd(event);
+      const startIndex = dayEnds.findIndex((dayEnd) => dayEnd > event.startTime);
+      // Last column the event still covers: exclusive end, so a span ending
+      // exactly at midnight stops on the previous day.
+      let endIndex = startIndex;
+      for (let i = days.length - 1; i >= 0; i -= 1) {
+        if (dayStarts[i] < end) {
+          endIndex = i;
+          break;
+        }
+      }
+      return {
+        event,
+        startIndex: Math.max(startIndex, 0),
+        endIndex,
+        continuesBefore: event.startTime < rangeStart,
+        continuesAfter: end > rangeEnd,
+      };
+    })
+    // Longest bars first within a start column, so the eye follows stable rows.
+    .sort(
+      (a, b) =>
+        a.startIndex - b.startIndex ||
+        b.endIndex - b.startIndex - (a.endIndex - a.startIndex) ||
+        a.event.title.localeCompare(b.event.title),
+    );
+
+  /** Last occupied column per lane; a lane frees up the column after. */
+  const laneEnds: number[] = [];
+  return candidates.map((candidate) => {
+    let lane = laneEnds.findIndex((occupiedThrough) => occupiedThrough < candidate.startIndex);
+    if (lane === -1) {
+      lane = laneEnds.length;
+    }
+    laneEnds[lane] = candidate.endIndex;
+    return { ...candidate, lane };
+  });
+}
+
+/** How many lanes the spanning band needs to draw `spans`. */
+export function spanLaneCount(spans: readonly EventSpan[]): number {
+  return spans.reduce((max, s) => Math.max(max, s.lane + 1), 0);
+}
+
 // ── Event block presentation (week/day time grid) ────────────────────────────
 
 /** What an event block has room to render, given its pixel height. */

--- a/src/locales/de/calendar.json
+++ b/src/locales/de/calendar.json
@@ -99,5 +99,9 @@
     "change": "Ändern",
     "authError": "Deine Antwort konnte nicht gesendet werden. Melde dich erneut bei diesem Konto an, um Kalenderzugriff zu gewähren.",
     "error": "Deine Antwort konnte nicht gesendet werden: {{message}}"
+  },
+  "calendars": {
+    "hideOne": "{{name}} ausblenden",
+    "showOne": "{{name}} einblenden"
   }
 }

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -432,7 +432,8 @@
     "notificationsDesc": "Werde vor einem anstehenden Meeting benachrichtigt, mit direktem Teilnahme-Link.",
     "leadTimeLabel": "Vorlaufzeit der Benachrichtigung",
     "leadTimeDesc": "Wie lange vor Beginn des Meetings die Benachrichtigung erscheint.",
-    "minutesOption": "{{n}} Minuten"
+    "minutesOption": "{{n}} Minuten",
+    "primaryCalendar": "primär"
   },
   "aiTranslation": {
     "enable": "KI-Übersetzung aktivieren",

--- a/src/locales/en/calendar.json
+++ b/src/locales/en/calendar.json
@@ -99,5 +99,9 @@
     "change": "Change",
     "authError": "Couldn't send your response. Sign in to this account again to grant calendar access.",
     "error": "Couldn't send your response: {{message}}"
+  },
+  "calendars": {
+    "hideOne": "Hide {{name}}",
+    "showOne": "Show {{name}}"
   }
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -432,7 +432,8 @@
     "notificationsDesc": "Get notified before an upcoming meeting, with a direct join link.",
     "leadTimeLabel": "Notification lead time",
     "leadTimeDesc": "How long before the meeting starts the notification fires.",
-    "minutesOption": "{{n}} minutes"
+    "minutesOption": "{{n}} minutes",
+    "primaryCalendar": "primary"
   },
   "aiTranslation": {
     "enable": "Enable AI translation",

--- a/src/locales/es/calendar.json
+++ b/src/locales/es/calendar.json
@@ -99,5 +99,9 @@
     "change": "Cambiar",
     "authError": "No se pudo enviar tu respuesta. Inicia sesión de nuevo en esta cuenta para conceder acceso al calendario.",
     "error": "No se pudo enviar tu respuesta: {{message}}"
+  },
+  "calendars": {
+    "hideOne": "Ocultar {{name}}",
+    "showOne": "Mostrar {{name}}"
   }
 }

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -432,7 +432,8 @@
     "notificationsDesc": "Recibe un aviso antes de cada reunión, con enlace directo para unirte.",
     "leadTimeLabel": "Antelación del aviso",
     "leadTimeDesc": "Cuánto tiempo antes del inicio de la reunión se envía el aviso.",
-    "minutesOption": "{{n}} minutos"
+    "minutesOption": "{{n}} minutos",
+    "primaryCalendar": "principal"
   },
   "aiTranslation": {
     "enable": "Activar traducción con IA",

--- a/src/locales/fr/calendar.json
+++ b/src/locales/fr/calendar.json
@@ -99,5 +99,9 @@
     "change": "Modifier",
     "authError": "Impossible d'envoyer votre réponse. Reconnectez-vous à ce compte pour accorder l'accès au calendrier.",
     "error": "Impossible d'envoyer votre réponse : {{message}}"
+  },
+  "calendars": {
+    "hideOne": "Masquer {{name}}",
+    "showOne": "Afficher {{name}}"
   }
 }

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -432,7 +432,8 @@
     "notificationsDesc": "Soyez averti avant une réunion, avec un lien direct pour la rejoindre.",
     "leadTimeLabel": "Délai de notification",
     "leadTimeDesc": "Combien de temps avant le début de la réunion la notification est envoyée.",
-    "minutesOption": "{{n}} minutes"
+    "minutesOption": "{{n}} minutes",
+    "primaryCalendar": "principal"
   },
   "aiTranslation": {
     "enable": "Activer la traduction IA",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,28 @@ export interface CalendarAttendee {
   response: string;
 }
 
+/** One calendar an account can see — its own, shared with it, or subscribed.
+ *  Mirrors the Rust `Calendar` struct in `src-tauri/src/models/mod.rs`.
+ *  Refreshed from the provider on every sync except `isVisible`, which is the
+ *  local show/hide toggle. */
+export interface Calendar {
+  id: string;
+  accountId: string;
+  /** Provider calendar id: an address on Google, an opaque id on Graph. */
+  providerCalendarId: string;
+  name: string;
+  /** Provider colour as "#rrggbb", or '' when the provider reported none —
+   *  resolve through `calendarColor()` rather than reading this directly. */
+  color: string;
+  isPrimary: boolean;
+  /** 'owner' | 'writer' | 'reader' | 'freeBusyReader' */
+  accessRole: string;
+  isVisible: boolean;
+  sortOrder: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
 /** A calendar event synced from Gmail / Outlook. Mirrors the Rust
  *  `CalendarEvent` struct in `src-tauri/src/models/mod.rs` (camelCase serde).
  *  `description` may contain raw provider HTML (Graph) — treat as UNTRUSTED


### PR DESCRIPTION
Calendar sync only ever fetched the primary calendar, so a calendar shared with the account was invisible in the app while being visible in the provider's own UI. Sync now enumerates every calendar an account can see (Google calendarList.list, Graph /me/calendars) and tints each event with that calendar's own provider colour.

All calendars sync; a per-calendar visibility toggle (legend above the grid, plus a list in Settings -> Calendar) filters at render time, so re-showing a calendar is instant instead of a poll away. Calendars the provider reports no colour for get a deterministic slot from an app palette, keyed on the calendar id so colours never shuffle.

Two listings now exist by design: list_calendar_events returns everything and backs the calendar view, which filters client-side; list_visible_calendar_events excludes hidden calendars and backs everything that acts on events -- meeting notifications, the chat calendar tool, and the CLI. Otherwise a calendar the user switched off would still raise reminders.

V022 re-keys calendar_events to (account_id, calendar_id, provider_event_id) via a table rebuild. Providers reuse one event id for every copy of a meeting you attend, so an event visible in both the primary and a shared calendar collided under the old key and one copy silently overwrote the other. A test runs the migration file against a pre-V022 table to prove existing rows survive the rebuild.

Google needs the extra calendar.calendarlist.readonly scope -- calendar.events cannot list calendars. It is the narrowest scope that works, but existing Gmail accounts must re-consent and the pending verification submission has to list it. Graph needed no scope change.

Multi-day events are now drawn once as a bar spanning the days they cover, with chevrons where they continue past the visible range, instead of a full-height block repeated in every column relabelled with the absolute start/end times. "Multi-day" is duration > 24h, so a meeting crossing midnight stays in the time grid where it belongs.

Per-calendar sync failures are isolated: one calendar erroring is logged and skipped, its events are spared the stale sweep, and the rest still sync. Only an all-calendars failure propagates, preserving the scheduler's permission-denied auto-disable.

## Summary

<!-- What does this PR do and why? One or two sentences. -->

## Changes

<!-- Bullet list of the concrete changes (code, config, docs). -->

-
-

## Testing

<!--
How did you verify the change? Run the actual commands.
Examples:
- `npm run test:frontend`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- Manual repro steps in the desktop app
-->

- [ ] `npx tsc --noEmit` passes
- [ ] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` passes
- [ ] Tests added/updated for behavior changes (TDD)

## Privacy / security

<!--
Does this PR add network calls, change OAuth/keychain handling, touch the
HTML sanitizer, or alter the CSP? If yes, describe the impact. If no,
write "no impact".
-->

## Screenshots / recordings

<!-- For UI changes, attach a screenshot or short clip. -->

## Related issues

<!-- e.g. Closes #123, Refs #45 -->
