### PR TITLE
Archive repository traffic alongside downloads

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -3,9 +3,15 @@
 #
 # GitHub reports `download_count` but keeps no history of it, and the app ships
 # no telemetry by design — so this workflow *is* the adoption record. It runs
-# once a day, appends a row to a CSV on the orphan `metrics` branch (never on
-# `main`, see scripts/metrics_history.sh) and posts the report as a comment on
-# a single long-lived issue.
+# once a day, appends a row to three CSVs on the orphan `metrics` branch (never
+# on `main`, see scripts/metrics_history.sh) and posts the report as a comment
+# on a single long-lived issue.
+#
+# It also archives repository traffic — views, clones and referrers. GitHub
+# keeps those for 14 days and then discards them, so without this the evidence
+# for any spike is gone by the time the spike is worth explaining. Those three
+# endpoints need push access and the run's token may not have it; when they
+# answer 403 the step logs why and the rest of the report still goes out.
 #
 # That comment is the delivery mechanism: GitHub mails you every comment on a
 # thread you are subscribed to, so the daily report lands in the same inbox as
@@ -31,10 +37,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Push the history commit to the `metrics` branch.
+  # Push the history commit to the `metrics` branch. Also the closest thing to
+  # the "push access" the traffic endpoints ask for — whether GITHUB_TOKEN is
+  # actually accepted there is what the first run will tell us.
   contents: write
   # Open the metrics issue once, then comment on it daily.
   issues: write
+  # Traffic lives under the repository's administration scope on some setups.
+  administration: read
 
 concurrency:
   group: metrics
@@ -52,19 +62,23 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Pull the stored history
-        run: bash scripts/metrics_history.sh pull downloads.csv
+        run: bash scripts/metrics_history.sh pull history
 
       - name: Collect today's numbers and post the report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/repo_metrics.mjs --history downloads.csv
+        run: |
+          node scripts/repo_metrics.mjs \
+            --history history/downloads.csv \
+            --traffic-history history/traffic.csv \
+            --referrer-history history/referrers.csv
 
       # `always()` so a failed post (GitHub API blip) still records the day.
       # A collector that failed before writing leaves the file exactly as it
       # was pulled, and the push step then finds nothing to commit.
       - name: Store the updated history
         if: always()
-        run: bash scripts/metrics_history.sh push downloads.csv
+        run: bash scripts/metrics_history.sh push history
         env:
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -701,3 +701,23 @@ an orphan branch shares no history with `main` and holds exactly one file. *A
 Claude Routine on a schedule* — the fired sessions get no MCP tools, and GitHub is
 reachable only through MCP in that environment, so the job could never read a single
 `download_count`.
+
+## 2026-09-04 — Repository traffic is archived daily, because GitHub forgets it
+
+**Decision:** The metrics workflow also snapshots `/traffic/views`, `/traffic/clones` and
+`/traffic/popular/referrers` every day, into `traffic.csv` and `referrers.csv` on the
+same orphan `metrics` branch, and puts today's visits and top referrers in the daily
+report. The traffic endpoints need push access that the run's `GITHUB_TOKEN` may not
+have; when they answer 403 the run logs why and reports downloads and stars as before.
+**Context:** Downloads went from 124 to 200 in ten days with no release in between, so
+the growth was new users rather than the update toast — and there was no way to tell
+which channel had sent them, because GitHub keeps traffic for only 14 days and then
+discards it. The referrer list is the one thing that names the channel, and it expires
+before a weekly review would ever catch it. Archiving it costs one API call a day.
+**Rejected:** *A personal access token* to guarantee the traffic endpoints answer — it
+reintroduces exactly the stored, rotatable secret that the issue-comment delivery was
+chosen to avoid; if `GITHUB_TOKEN` turns out not to be enough, the right answer is to
+drop the traffic half, not to add a secret. *Storing the 14-day totals* each payload
+carries — they are a rolling sum, meaningless once stitched into a history, so only the
+per-day breakdown is kept. *A separate workflow* — same schedule, same branch, same
+report; a second job would just double the moving parts.

--- a/scripts/metrics_history.sh
+++ b/scripts/metrics_history.sh
@@ -1,63 +1,72 @@
 #!/usr/bin/env bash
-# Read/write the release-metrics history (`.github/workflows/metrics.yml`).
+# Read/write the metrics history (`.github/workflows/metrics.yml`).
 #
-# The history is one CSV that grows by a row a day. It deliberately does NOT
-# live on `main`: a daily bot commit there would bury real work in the log and
-# show up in every `git log`, blame and release diff. Instead it lives alone on
-# an orphan `metrics` branch, which shares no history with `main` and holds
-# exactly one file.
+# The history is a handful of CSVs that grow by a row a day: downloads/stars,
+# per-day traffic, and dated referrer snapshots. They deliberately do NOT live
+# on `main`: a daily bot commit there would bury real work in the log and show
+# up in every `git log`, blame and release diff. Instead they live alone on an
+# orphan `metrics` branch, which shares no history with `main`.
 #
 # `push` writes that branch with git plumbing (hash-object → mktree →
 # commit-tree) rather than checking the branch out. Switching branches mid-job
 # would fight the workflow's checkout of `main`, and a worktree would need a
 # second clone; plumbing just builds the commit object and pushes it.
 #
-#   scripts/metrics_history.sh pull <csv-path>   # newest history, or empty file
-#   scripts/metrics_history.sh push <csv-path>   # commit + push if it changed
+# Both commands work on a DIRECTORY, not a single file, and `push` rebuilds the
+# tree from every CSV in it. That is load-bearing: `mktree` writes a whole tree,
+# so committing one file at a time would drop the others from the branch.
+#
+#   scripts/metrics_history.sh pull <dir>   # stored CSVs into <dir> (may be none)
+#   scripts/metrics_history.sh push <dir>   # commit + push if anything changed
 
 set -euo pipefail
 
 BRANCH="${METRICS_BRANCH:-metrics}"
-FILENAME="downloads.csv"
 
 usage() {
-  echo "usage: $0 {pull|push} <csv-path>" >&2
+  echo "usage: $0 {pull|push} <dir>" >&2
   exit 2
 }
 
 [ $# -eq 2 ] || usage
 command="$1"
-path="$2"
+dir="$2"
 
 case "$command" in
   pull)
-    # A missing branch is the expected first run: hand back an empty file and
-    # let the collector start a fresh history.
+    mkdir -p "$dir"
+    # A missing branch is the expected first run: leave the directory empty and
+    # let the collector start fresh histories.
     if git fetch --quiet origin "$BRANCH" 2>/dev/null; then
-      git show "FETCH_HEAD:$FILENAME" > "$path"
-      echo "[metrics] pulled $(( $(wc -l < "$path") - 1 )) rows from origin/$BRANCH"
+      for name in $(git ls-tree --name-only FETCH_HEAD); do
+        git show "FETCH_HEAD:$name" > "$dir/$name"
+        echo "[metrics] pulled $name ($(( $(wc -l < "$dir/$name") - 1 )) rows)"
+      done
     else
-      : > "$path"
       echo "[metrics] no origin/$BRANCH yet — starting a new history"
     fi
     ;;
 
   push)
-    [ -s "$path" ] || { echo "[metrics] $path is empty — refusing to push" >&2; exit 1; }
+    entries=$(
+      for file in "$dir"/*.csv; do
+        [ -s "$file" ] || continue
+        printf '100644 blob %s\t%s\n' "$(git hash-object -w "$file")" "$(basename "$file")"
+      done
+    )
+    [ -n "$entries" ] || { echo "[metrics] no non-empty CSV in $dir — refusing to push" >&2; exit 1; }
+    tree=$(printf '%s\n' "$entries" | git mktree)
 
     parent=""
     if git fetch --quiet origin "$BRANCH" 2>/dev/null; then
       parent=$(git rev-parse FETCH_HEAD)
-      # Nothing to record when the file is byte-identical to what is already
-      # on the branch — a quiet day should not create an empty commit.
-      if git show "$parent:$FILENAME" 2>/dev/null | cmp -s - "$path"; then
+      # Comparing trees, not files: a quiet day should not create an empty commit.
+      if [ "$(git rev-parse "$parent^{tree}")" = "$tree" ]; then
         echo "[metrics] history unchanged — nothing to push"
         exit 0
       fi
     fi
 
-    blob=$(git hash-object -w "$path")
-    tree=$(printf '100644 blob %s\t%s\n' "$blob" "$FILENAME" | git mktree)
     message="metrics: $(date -u +%Y-%m-%d)"
     if [ -n "$parent" ]; then
       commit=$(git commit-tree "$tree" -p "$parent" -m "$message")

--- a/scripts/repo_metrics.mjs
+++ b/scripts/repo_metrics.mjs
@@ -4,10 +4,14 @@
 // GitHub exposes a per-asset `download_count` but no history for it: the API
 // only ever tells you today's number. Adoption is the one signal this project
 // has — there is no telemetry in the app, by design — so the history has to be
-// kept here. Each run appends one row (date, total downloads, stars) to a CSV
-// and posts the current numbers, plus the deltas that CSV makes computable, as
-// a comment on a long-lived issue — GitHub's own notification mail delivers it,
-// so there is no SMTP secret to configure anywhere.
+// kept here. Traffic has the same problem and worse: GitHub keeps views,
+// clones and referrers for 14 days and then discards them, so by the time a
+// spike is worth explaining the evidence is gone.
+//
+// Each run appends a row to three CSVs — downloads/stars, per-day traffic, and
+// a dated referrer snapshot — and posts the current numbers, plus the deltas
+// those CSVs make computable, as a comment on a long-lived issue. GitHub's own
+// notification mail delivers it, so there is no SMTP secret to configure.
 //
 // Everything above `main()` is pure: it takes releases, a star count, the
 // stored history and today's date, and returns numbers and strings. That is
@@ -61,21 +65,95 @@ export function summarize(releases) {
   return { total, byPlatform, byRelease };
 }
 
-const HEADER = 'date,total,stars';
-
-export function parseHistory(csv) {
-  return csv
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line !== '' && line !== HEADER)
-    .map((line) => {
-      const [date, total, stars] = line.split(',');
-      return { date, total: Number(total), stars: Number(stars) };
-    });
+/**
+ * CSV codec for a fixed column list. Three histories share it — downloads,
+ * traffic and referrers — so the archive format is defined in exactly one
+ * place. `numeric` names the columns to coerce back to numbers on read.
+ */
+function csvCodec(columns, numeric) {
+  const header = columns.join(',');
+  return {
+    parse(text) {
+      return text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line !== '' && line !== header)
+        .map((line) => {
+          const cells = line.split(',');
+          return Object.fromEntries(
+            columns.map((col, i) => [col, numeric.includes(col) ? Number(cells[i]) : cells[i]]),
+          );
+        });
+    },
+    serialize(rows) {
+      const body = rows.map((row) => columns.map((col) => row[col]).join(','));
+      return `${[header, ...body].join('\n')}\n`;
+    },
+  };
 }
 
-export function serializeHistory(rows) {
-  return `${[HEADER, ...rows.map((r) => `${r.date},${r.total},${r.stars}`)].join('\n')}\n`;
+const DOWNLOADS_CSV = csvCodec(['date', 'total', 'stars'], ['total', 'stars']);
+const TRAFFIC_CSV = csvCodec(
+  ['date', 'views', 'unique_views', 'clones', 'unique_clones'],
+  ['views', 'unique_views', 'clones', 'unique_clones'],
+);
+const REFERRERS_CSV = csvCodec(['date', 'referrer', 'count', 'uniques'], ['count', 'uniques']);
+
+export const parseHistory = (csv) => DOWNLOADS_CSV.parse(csv);
+export const serializeHistory = (rows) => DOWNLOADS_CSV.serialize(rows);
+export const parseTrafficHistory = (csv) => TRAFFIC_CSV.parse(csv);
+export const serializeTrafficHistory = (rows) => TRAFFIC_CSV.serialize(rows);
+export const parseReferrerHistory = (csv) => REFERRERS_CSV.parse(csv);
+export const serializeReferrerHistory = (rows) => REFERRERS_CSV.serialize(rows);
+
+/**
+ * Fold `/traffic/views` and `/traffic/clones` into one row per day. The two
+ * endpoints report independent day lists — a day with visits but no clone
+ * appears in one and not the other — so days are unioned, not zipped. Only the
+ * per-day breakdown is kept: the `count`/`uniques` at the top of each payload
+ * are a rolling 14-day sum and would be meaningless stitched into a history.
+ */
+export function trafficRows(views, clones) {
+  const byDate = new Map();
+  const row = (timestamp) => {
+    const date = timestamp.slice(0, 10);
+    if (!byDate.has(date)) {
+      byDate.set(date, { date, views: 0, unique_views: 0, clones: 0, unique_clones: 0 });
+    }
+    return byDate.get(date);
+  };
+  for (const day of views?.views ?? []) {
+    const target = row(day.timestamp);
+    target.views = day.count;
+    target.unique_views = day.uniques;
+  }
+  for (const day of clones?.clones ?? []) {
+    const target = row(day.timestamp);
+    target.clones = day.count;
+    target.unique_clones = day.uniques;
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Overlay the freshly fetched 14-day window on the stored history. Days inside
+ * the window are replaced (GitHub revises them as the day advances); days that
+ * have scrolled out of it survive — which is the entire point of archiving.
+ */
+export function mergeTrafficHistory(stored, fresh) {
+  const refreshed = new Set(fresh.map((r) => r.date));
+  return [...stored.filter((r) => !refreshed.has(r.date)), ...fresh].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Referrers come as a top-10 snapshot with no dates of their own, so each run
+ * stamps today's date on them. A re-run the same day replaces that snapshot.
+ */
+export function mergeReferrerHistory(stored, fresh, today) {
+  return [
+    ...stored.filter((r) => r.date !== today),
+    ...fresh.map((r) => ({ date: today, referrer: r.referrer, count: r.count, uniques: r.uniques })),
+  ];
 }
 
 /**
@@ -113,7 +191,7 @@ const PLATFORM_LABELS = { macos: 'macOS', windows: 'Windows', linux: 'Linux', cl
  * previous row is the day-over-day baseline. On the very first run there is no
  * previous row and every delta is omitted — a cold start is not a spike.
  */
-export function buildReport({ summary, stars, history, today }) {
+export function buildReport({ summary, stars, history, today, traffic = null }) {
   const previous = history.filter((r) => r.date < today).slice(-1)[0] ?? null;
   const week = previous ? baselineRow(history, today, 7) : null;
 
@@ -144,6 +222,14 @@ export function buildReport({ summary, stars, history, today }) {
   for (const [key, count] of platformRows) lines.push(`  ${PLATFORM_LABELS[key]}: ${count}`);
   lines.push('', 'Por release:');
   for (const rel of releaseRows) lines.push(`  ${rel.tag}: ${rel.downloads}`);
+  if (traffic?.today) {
+    const t = traffic.today;
+    lines.push('', `Visitas hoy: ${t.views} (${t.unique_views} únicas)  Clones: ${t.clones} (${t.unique_clones})`);
+    if (traffic.referrers?.length) {
+      lines.push('Referrers:');
+      for (const ref of traffic.referrers) lines.push(`  ${ref.referrer}: ${ref.count} (${ref.uniques} únicas)`);
+    }
+  }
   lines.push('', 'Últimos días:');
   for (const row of recent) lines.push(`  ${row.date}  ${row.total} descargas  ${row.stars} estrellas`);
   lines.push('', `https://github.com/${REPO}/releases`);
@@ -159,6 +245,21 @@ export function buildReport({ summary, stars, history, today }) {
       platformRows.map(([k, v]) => `| ${PLATFORM_LABELS[k]} | ${v} |`),
     ),
     '',
+    ...(traffic?.today
+      ? [
+          `Visitas hoy: **${traffic.today.views}** (${traffic.today.unique_views} únicas) · Clones: ${traffic.today.clones} (${traffic.today.unique_clones})`,
+          '',
+          ...(traffic.referrers?.length
+            ? [
+                table(
+                  ['Referrer', 'Visitas'],
+                  traffic.referrers.map((r) => `| ${escapeCell(r.referrer)} | ${r.count} (${r.uniques}) |`),
+                ),
+                '',
+              ]
+            : []),
+        ]
+      : []),
     '<details><summary>Por release</summary>',
     '',
     table(
@@ -241,6 +342,29 @@ async function postReport(markdown, title) {
   console.log(`[metrics] posted ${comment.html_url}`);
 }
 
+/**
+ * Views, clones and top referrers for the last 14 days — the window GitHub
+ * keeps and then discards, which is why they are archived here.
+ *
+ * These three endpoints need push access, and the token a run happens to carry
+ * may not have it. That must never sink the run: on any failure the collector
+ * reports what it does have and says why the rest is missing.
+ */
+async function fetchTraffic() {
+  try {
+    const [views, clones, referrers] = await Promise.all([
+      githubJson(`/repos/${REPO}/traffic/views`),
+      githubJson(`/repos/${REPO}/traffic/clones`),
+      githubJson(`/repos/${REPO}/traffic/popular/referrers`),
+    ]);
+    return { views, clones, referrers };
+  } catch (err) {
+    console.error(`[metrics] traffic unavailable, skipping it: ${err.message}`);
+    console.error('[metrics] these endpoints need push access — check the workflow token permissions');
+    return null;
+  }
+}
+
 async function fetchAllReleases() {
   const all = [];
   for (let page = 1; ; page += 1) {
@@ -258,25 +382,49 @@ function arg(argv, name, fallback) {
 async function main(argv) {
   const dryRun = argv.includes('--dry-run');
   const historyPath = arg(argv, '--history', 'downloads.csv');
+  const trafficPath = arg(argv, '--traffic-history', 'traffic.csv');
+  const referrerPath = arg(argv, '--referrer-history', 'referrers.csv');
   const today = arg(argv, '--today', new Date().toISOString().slice(0, 10));
   const issueTitle = arg(argv, '--issue-title', ISSUE_TITLE);
 
-  const [releases, repo] = await Promise.all([fetchAllReleases(), githubJson(`/repos/${REPO}`)]);
+  const [releases, repo, rawTraffic] = await Promise.all([
+    fetchAllReleases(),
+    githubJson(`/repos/${REPO}`),
+    fetchTraffic(),
+  ]);
   const summary = summarize(releases);
   const stars = repo.stargazers_count;
 
-  let stored = [];
-  try {
-    stored = parseHistory(readFileSync(historyPath, 'utf8'));
-  } catch (err) {
-    // A missing file is the expected first run; anything else (unreadable,
-    // corrupt) must surface rather than silently resetting the history.
-    if (err.code !== 'ENOENT') throw err;
-    console.error(`[metrics] no history at ${historyPath} — starting a new one`);
+  // A missing file is the expected first run; anything else (unreadable,
+  // corrupt) must surface rather than silently resetting the history.
+  const read = (path, parse) => {
+    try {
+      return parse(readFileSync(path, 'utf8'));
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+      console.error(`[metrics] no history at ${path} — starting a new one`);
+      return [];
+    }
+  };
+
+  const history = upsertRow(read(historyPath, parseHistory), { date: today, total: summary.total, stars });
+
+  let traffic = null;
+  let trafficHistory = null;
+  let referrerHistory = null;
+  if (rawTraffic) {
+    trafficHistory = mergeTrafficHistory(
+      read(trafficPath, parseTrafficHistory),
+      trafficRows(rawTraffic.views, rawTraffic.clones),
+    );
+    referrerHistory = mergeReferrerHistory(read(referrerPath, parseReferrerHistory), rawTraffic.referrers, today);
+    traffic = {
+      today: trafficHistory.find((r) => r.date === today) ?? null,
+      referrers: rawTraffic.referrers,
+    };
   }
 
-  const history = upsertRow(stored, { date: today, total: summary.total, stars });
-  const report = buildReport({ summary, stars, history, today });
+  const report = buildReport({ summary, stars, history, today, traffic });
 
   if (dryRun) {
     console.log(report.subject);
@@ -286,6 +434,8 @@ async function main(argv) {
   }
 
   writeFileSync(historyPath, serializeHistory(history));
+  if (trafficHistory) writeFileSync(trafficPath, serializeTrafficHistory(trafficHistory));
+  if (referrerHistory) writeFileSync(referrerPath, serializeReferrerHistory(referrerHistory));
   await postReport(report.markdown, issueTitle);
 
   const previous = history.filter((r) => r.date < today).slice(-1)[0] ?? null;

--- a/scripts/repo_metrics.test.mjs
+++ b/scripts/repo_metrics.test.mjs
@@ -11,9 +11,14 @@ import {
   buildReport,
   classifyAsset,
   findMetricsIssue,
+  mergeReferrerHistory,
+  mergeTrafficHistory,
   parseHistory,
+  parseTrafficHistory,
   serializeHistory,
+  serializeTrafficHistory,
   summarize,
+  trafficRows,
   upsertRow,
 } from './repo_metrics.mjs';
 
@@ -206,7 +211,10 @@ describe('findMetricsIssue', () => {
   const title = '📊 Métricas de descargas y estrellas';
 
   it('finds the open issue with the metrics title', () => {
-    const issues = [{ number: 3, title: 'Otro asunto' }, { number: 7, title }];
+    const issues = [
+      { number: 3, title: 'Otro asunto' },
+      { number: 7, title },
+    ];
     expect(findMetricsIssue(issues, title)?.number).toBe(7);
   });
 
@@ -219,5 +227,119 @@ describe('findMetricsIssue', () => {
 
   it('returns null when the issue does not exist yet', () => {
     expect(findMetricsIssue([], title)).toBeNull();
+  });
+});
+
+describe('traffic', () => {
+  // Shape of /traffic/views and /traffic/clones: a total, a unique count, and
+  // a per-day breakdown. Only the per-day rows are archived — the totals are
+  // a rolling 14-day sum and mean nothing once stitched into a history.
+  const views = {
+    count: 120,
+    uniques: 40,
+    views: [
+      { timestamp: '2026-09-03T00:00:00Z', count: 50, uniques: 18 },
+      { timestamp: '2026-09-04T00:00:00Z', count: 70, uniques: 22 },
+    ],
+  };
+  const clones = {
+    count: 9,
+    uniques: 5,
+    clones: [
+      { timestamp: '2026-09-03T00:00:00Z', count: 4, uniques: 2 },
+      { timestamp: '2026-09-04T00:00:00Z', count: 5, uniques: 3 },
+    ],
+  };
+
+  it('turns the API payloads into one row per day', () => {
+    expect(trafficRows(views, clones)).toEqual([
+      { date: '2026-09-03', views: 50, unique_views: 18, clones: 4, unique_clones: 2 },
+      { date: '2026-09-04', views: 70, unique_views: 22, clones: 5, unique_clones: 3 },
+    ]);
+  });
+
+  // GitHub reports views and clones on independent day lists: a day with
+  // traffic but no clone appears in one and not the other.
+  it('fills a day that only one of the two endpoints reports', () => {
+    const lonely = { count: 1, uniques: 1, clones: [{ timestamp: '2026-09-05T00:00:00Z', count: 1, uniques: 1 }] };
+    expect(trafficRows(views, lonely)).toEqual([
+      { date: '2026-09-03', views: 50, unique_views: 18, clones: 0, unique_clones: 0 },
+      { date: '2026-09-04', views: 70, unique_views: 22, clones: 0, unique_clones: 0 },
+      { date: '2026-09-05', views: 0, unique_views: 0, clones: 1, unique_clones: 1 },
+    ]);
+  });
+
+  it('round-trips a traffic history through CSV', () => {
+    const rows = trafficRows(views, clones);
+    expect(parseTrafficHistory(serializeTrafficHistory(rows))).toEqual(rows);
+  });
+
+  // The 14-day window is the whole reason this exists: a re-fetched day must
+  // correct the stored row, and days that scrolled out of the window must
+  // survive in the history.
+  it('merges a fresh window over the stored history, keeping older days', () => {
+    const stored = [
+      { date: '2026-08-01', views: 5, unique_views: 2, clones: 0, unique_clones: 0 },
+      { date: '2026-09-03', views: 1, unique_views: 1, clones: 0, unique_clones: 0 },
+    ];
+    expect(mergeTrafficHistory(stored, trafficRows(views, clones))).toEqual([
+      { date: '2026-08-01', views: 5, unique_views: 2, clones: 0, unique_clones: 0 },
+      { date: '2026-09-03', views: 50, unique_views: 18, clones: 4, unique_clones: 2 },
+      { date: '2026-09-04', views: 70, unique_views: 22, clones: 5, unique_clones: 3 },
+    ]);
+  });
+
+  it('appends dated referrer snapshots without losing earlier ones', () => {
+    const stored = [{ date: '2026-09-03', referrer: 'google.com', count: 4, uniques: 3 }];
+    const fresh = [
+      { referrer: 'news.ycombinator.com', count: 30, uniques: 25 },
+      { referrer: 'google.com', count: 6, uniques: 4 },
+    ];
+    expect(mergeReferrerHistory(stored, fresh, '2026-09-04')).toEqual([
+      { date: '2026-09-03', referrer: 'google.com', count: 4, uniques: 3 },
+      { date: '2026-09-04', referrer: 'news.ycombinator.com', count: 30, uniques: 25 },
+      { date: '2026-09-04', referrer: 'google.com', count: 6, uniques: 4 },
+    ]);
+  });
+
+  it('replaces a same-day referrer snapshot on a re-run', () => {
+    const stored = [{ date: '2026-09-04', referrer: 'google.com', count: 1, uniques: 1 }];
+    const fresh = [{ referrer: 'google.com', count: 6, uniques: 4 }];
+    expect(mergeReferrerHistory(stored, fresh, '2026-09-04')).toEqual([
+      { date: '2026-09-04', referrer: 'google.com', count: 6, uniques: 4 },
+    ]);
+  });
+});
+
+describe('buildReport with traffic', () => {
+  const summary = {
+    total: 200,
+    byPlatform: { macos: 104, windows: 58, linux: 35, cli: 3, other: 0 },
+    byRelease: [{ tag: 'v0.6.6', downloads: 60 }],
+  };
+  const history = [
+    { date: '2026-09-03', total: 188, stars: 12 },
+    { date: '2026-09-04', total: 200, stars: 12 },
+  ];
+  const traffic = {
+    today: { date: '2026-09-04', views: 70, unique_views: 22, clones: 5, unique_clones: 3 },
+    referrers: [
+      { referrer: 'news.ycombinator.com', count: 30, uniques: 25 },
+      { referrer: 'google.com', count: 6, uniques: 4 },
+    ],
+  };
+
+  it('reports visits and the top referrers when traffic is available', () => {
+    const { markdown } = buildReport({ summary, stars: 12, history, today: '2026-09-04', traffic });
+    expect(markdown).toContain('70');
+    expect(markdown).toContain('news.ycombinator.com');
+  });
+
+  // The traffic API needs push access and may answer 403. That must degrade to
+  // a report without a traffic section, never to a failed run.
+  it('omits the traffic section entirely when traffic is unavailable', () => {
+    const { markdown } = buildReport({ summary, stars: 12, history, today: '2026-09-04', traffic: null });
+    expect(markdown).not.toContain('Visitas');
+    expect(markdown).toContain('200 descargas');
   });
 });


### PR DESCRIPTION
## Summary

The daily metrics collector now also snapshots repository traffic — views, clones and top referrers — onto the `metrics` branch, and puts today's visits and referrers in the report. GitHub keeps that data for 14 days and then discards it, so without this the evidence for any spike is gone by the time the spike is worth explaining.

The motivating case: downloads went 124 → 200 in ten days with **no release in between**, which rules out the update toast and means those were new users. Nothing recorded which channel sent them, and the referrer list that would have said so expires before a weekly review would ever catch it.

## Changes

- **`scripts/repo_metrics.mjs`** fetches `/traffic/views`, `/traffic/clones` and `/traffic/popular/referrers`, merges them into `traffic.csv` (one row per day) and `referrers.csv` (a dated top-10 snapshot), and renders a visits line plus a referrer table in the report. Only the per-day breakdown is archived — the `count`/`uniques` at the top of each payload are a rolling 14-day sum and would be meaningless stitched into a history.
- **The 14-day window is merged, not appended:** days inside it are replaced on each run because GitHub revises them as the day advances; days that have scrolled out survive, which is the whole point.
- **A shared CSV codec** replaces the bespoke downloads parser, so all three histories define their format in one place.
- **`scripts/metrics_history.sh` now works on a directory** and rebuilds the branch tree from every CSV in it. This is load-bearing: `git mktree` writes a whole tree, so committing one file at a time would have silently dropped the other two from the branch on every push. The no-op check now compares trees rather than file contents.
- **`administration: read`** added to the workflow permissions alongside the existing `contents: write` — the best guess at what the traffic endpoints require.

## Testing

- [x] `npx tsc --noEmit` passes
- [x] `cargo clippy ... -- -D warnings` — no Rust touched by this PR
- [x] Tests added/updated for behavior changes (TDD) — 8 new tests written before the code
- `npx vitest run` — 906 passed across 71 files (39 in the metrics collector)
- `biome check` clean, workflow YAML parses, `bash -n` clean on the shell script
- **The 403 path was rehearsed against a stub that denies all three traffic endpoints:** the run exits 0, records downloads and stars as before, posts a report with no traffic section, leaves `traffic.csv` untouched rather than truncating it, and logs the reason.
- **The `mktree` hazard was rehearsed against a local bare repo:** all three CSVs survive a push in which only one of them changed, an unchanged directory still produces no commit, and a fresh `pull` reads all three back.

## Privacy / security

No new secret, and none is wanted: the run keeps using the per-run `GITHUB_TOKEN`. Traffic data is aggregate — visit counts, clone counts and referring domains — with no per-visitor information available from these endpoints, and it never touches the app or a user's mailbox. No change to OAuth, keychain, the HTML sanitizer, or the CSP.

## Note

Whether `GITHUB_TOKEN` is accepted on the traffic endpoints depends on how the organization is configured, and it cannot be verified before this lands. **The first run on `main` will say so in its log.** If it turns out to be refused, the intended answer is to drop the traffic half rather than introduce a stored PAT — recorded in `docs/DECISIONS.md` along with the rest of the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hfQN3tFHNeLCGApKt4iKp

---
_Generated by [Claude Code](https://claude.ai/code/session_012hfQN3tFHNeLCGApKt4iKp)_