### PR TITLE
Fix metrics.yml: drop the invalid administration permission

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -40,11 +40,17 @@ permissions:
   # Push the history commit to the `metrics` branch. Also the closest thing to
   # the "push access" the traffic endpoints ask for — whether GITHUB_TOKEN is
   # actually accepted there is what the first run will tell us.
+  #
+  # There is no permission to add for traffic: `permissions:` accepts a fixed
+  # set of scopes (actions, checks, contents, deployments, discussions,
+  # id-token, issues, packages, pages, pull-requests, repository-projects,
+  # security-events, statuses) and `administration` is not among them — naming
+  # it makes the whole workflow unparseable, which is how this comment got
+  # written. Either `contents: write` is enough for the traffic endpoints or
+  # the traffic half has to go.
   contents: write
   # Open the metrics issue once, then comment on it daily.
   issues: write
-  # Traffic lives under the repository's administration scope on some setups.
-  administration: read
 
 concurrency:
   group: metrics


### PR DESCRIPTION
## Summary

`main` currently carries a `metrics.yml` that Actions refuses to parse. #51 added `administration: read` to the workflow's `permissions:` block as a guess at what the traffic endpoints require, and that key does not exist — the block accepts a fixed set of scopes. Actions rejects the whole file with `Unexpected value 'administration'`, so **the scheduled run would fail every day until this lands**. This removes the line.

## Changes

- Remove `administration: read` from `.github/workflows/metrics.yml`.
- Replace it with a comment listing the scopes `permissions:` actually accepts, so the same guess is not made again, and stating the consequence: either `contents: write` is enough for the traffic endpoints or the traffic half has to go.

## Testing

The point of failure was schema validation, which is exactly what the YAML parse in #51's checks did not cover — a workflow can be valid YAML and still be an invalid workflow. So this was verified by dispatching the real thing:

- `metrics.yml` dispatched on this branch → [run 33876372614](https://github.com/emailops/emailops/actions/runs/33876372614) parsed, ran and **succeeded**, all six steps green.
- The same run answers the open question from #51: the traffic endpoints are refused.
  ```
  [metrics] traffic unavailable, skipping it: GitHub GET /repos/emailops/emailops/traffic/views → HTTP 403 Forbidden
  [metrics] these endpoints need push access — check the workflow token permissions
  [metrics] posted .../issues/45#issuecomment-5540882263
  total=200 stars=12 changed=true
  ```
  The degradation path behaved as designed: run green, report posted, downloads and stars recorded, no traffic section, nothing truncated.

## Privacy / security

Removes a permission line; grants nothing. No impact.

## Follow-up

`GITHUB_TOKEN` cannot reach the traffic API — it is structural, not a setting, so no permissions tweak will fix it. Per `docs/DECISIONS.md` the intended answer is to drop the traffic half rather than store a PAT; that removal is a separate change, and this PR only gets `main` parsing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hfQN3tFHNeLCGApKt4iKp

---
_Generated by [Claude Code](https://claude.ai/code/session_012hfQN3tFHNeLCGApKt4iKp)_